### PR TITLE
fix: multiple results won't crash the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+## [2.0.0] - 2020-11-28
+### Breaking
+- `TestCase.result` is now a list instead of a single item.
+
+### Added
+- `TestCase` constructor supports `time` and `classname` as params.
+- `Result` object supports `text` attribute.
+
 ## [1.6.3] - 2020-11-24
 ### Fixed
 - `JunitXML.fromstring()` now handles various inputs.

--- a/README.rst
+++ b/README.rst
@@ -6,29 +6,29 @@ junitparser -- Pythonic JUnit/xUnit Result XML Parser
 .. image:: https://codecov.io/gh/weiwei/junitparser/branch/master/graph/badge.svg?token=UotlfRXNnK
    :target: https://codecov.io/gh/weiwei/junitparser
 
-What does it do?
-----------------
-
-junitparser is a JUnit/xUnit Result XML Parser. Use it to parse and manipulate
+junitparser handles JUnit/xUnit Result XML files. Use it to parse and manipulate
 existing Result XML files, or create new JUnit/xUnit result XMLs from scratch.
 
-There are already a lot of modules that converts JUnit/xUnit XML from a
-specific format, but you may run into some proprietory or less-known formats
-and you want to convert them and feed the result to another tool, or, you may
-want to manipulate the results in your own way. This is where junitparser come
-into handy.
+Features
+--------
 
-Why junitparser?
-----------------
+* Parse or modify existing JUnit/xUnit xml files.
+* Parse or modify non-standard or customized JUnit/xUnit xml files, by monkey
+  patching existing element definitions.
+* Create JUnit/xUnit test results from scratch.
+* Merge test result xml files.
+* Specify xml parser. For example you can use lxml to speed things up.
+* Invoke from command line, or `python -m junitparser`
+* Python 2 and 3 support (As of Nov 2020, 1/4 of the users are still on Python 
+  2, so there is no plan to drop Python 2 support)
 
-* Functionality. There are various JUnit/xUnit XML libraries, some does
-  parsing, some does XML generation, some does manipulation. This module does 
-  all in a single package.
-* Extensibility. JUnit/xUnit is hardly a standardized format. The base format
-  is somewhat universally agreed with, but beyond that, there could be "custom"
-  elements and attributes. junitparser aims to support them all, by
-  allowing the user to monkeypatch and subclass some base classes.
-* Pythonic. You can manipulate test cases and suites in a pythonic way.
+Note on version 2
+-----------------
+
+Version 2 improved support for pytest result xml files by fixing a few issues, 
+notably that there could be multiple <Failure> or <Error> entries. There is a 
+breaking change that ``TestCase.result`` is now a list instead of a single item.
+If you are using this attribute, please update your code accordingly.
 
 Installation
 -------------
@@ -54,10 +54,11 @@ format.
     from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error
 
     # Create cases
-    case1 = TestCase('case1')
-    case1.result = Skipped()
+    case1 = TestCase('case1', 'class.name', 0.5) # params are optional
+    case1.classname = "modified.class.name" # specify or change case attrs
+    case1.result = [Skipped()] # You can have a list of results
     case2 = TestCase('case2')
-    case2.result = Error('Example error message', 'the_error_type')
+    case2.result = [Error('Example error message', 'the_error_type')]
 
     # Create suite and add cases
     suite = TestSuite('suite1')
@@ -225,35 +226,11 @@ Command Line
 Test
 ----
 
-You can run the cases directly::
-
-    python test.py
-
-Or use pytest::
+The tests are written with python `unittest`, to run them, use pytest::
 
     pytest test.py
-
-Notes
------
-
-There are some other packages providing similar functionalities. They are
-out there for a longer time, but might not be as feature-rich or fun as 
-junitparser:
-
-* xunitparser_: Read JUnit/XUnit XML files and map them to Python objects
-* xunitgen_: Generate xUnit.xml files
-* xunitmerge_: Utility for merging multiple XUnit xml reports into a single
-  xml report.
-* `junit-xml`_: Creates JUnit XML test result documents that can be read by
-  tools such as Jenkins
-
-.. _xunitparser: https://pypi.python.org/pypi/xunitparser
-.. _xunitgen: https://pypi.python.org/pypi/xunitgen
-.. _xunitmerge: https://pypi.python.org/pypi/xunitmerge
-.. _`junit-xml`: https://pypi.python.org/pypi/junit-xml
-
 
 Contribute
 ----------
 
-Please do!
+PRs are welcome!

--- a/junitparser/__init__.py
+++ b/junitparser/__init__.py
@@ -14,4 +14,4 @@ from .junitparser import (
     FloatAttr,
 )
 
-version = "1.6.3"
+version = "2.0.0b1"

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -92,9 +92,7 @@ class IntAttr(Attr):
 
     def __get__(self, instance, cls):
         result = super(IntAttr, self).__get__(instance, cls)
-        if result is None and (
-            isinstance(instance, JUnitXml) or isinstance(instance, TestSuite)
-        ):
+        if result is None and isinstance(instance, (JUnitXml, TestSuite)):
             instance.update_statistics()
             result = super(IntAttr, self).__get__(instance, cls)
         return int(result) if result else None
@@ -114,9 +112,7 @@ class FloatAttr(Attr):
 
     def __get__(self, instance, cls):
         result = super(FloatAttr, self).__get__(instance, cls)
-        if result is None and (
-            isinstance(instance, JUnitXml) or isinstance(instance, TestSuite)
-        ):
+        if result is None and isinstance(instance, (JUnitXml, TestSuite)):
             instance.update_statistics()
             result = super(FloatAttr, self).__get__(instance, cls)
         return float(result) if result else None
@@ -161,8 +157,8 @@ class Element(with_metaclass(junitxml, object)):
                 ['%s="%s"' % (key, self._elem.attrib[key]) for key in keys]
             )
             return """<Element '%s' %s>""" % (tag, attrs_str)
-        else:
-            return """<Element '%s'>""" % tag
+
+        return """<Element '%s'>""" % tag
 
     def append(self, sub_elem):
         """Adds the element subelement to the end of this elements internal
@@ -408,12 +404,12 @@ class TestSuite(Element):
                 self.add_testsuite(suite)
             self.update_statistics()
             return self
-        else:
-            result = JUnitXml()
-            result.filepath = self.filepath
-            result.add_testsuite(self)
-            result.add_testsuite(other)
-            return result
+
+        result = JUnitXml()
+        result.filepath = self.filepath
+        result.add_testsuite(self)
+        result.add_testsuite(other)
+        return result
 
     def remove_testcase(self, testcase):
         """Removes a test case from the suite."""
@@ -669,9 +665,8 @@ class TestCase(Element):
         """A list of Failure, Skipped, or Error objects."""
         results = []
         for entry in self:
-            for Res in POSSIBLE_RESULTS:
-                if isinstance(entry, Res):
-                    results.append(entry)
+            if isinstance(entry, tuple(POSSIBLE_RESULTS)):
+                results.append(entry)
 
         return results
 

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -55,9 +55,10 @@ class Test_RealFile(unittest.TestCase):
         self.assertEqual(len(suite2), 3)
         self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
         self.assertEqual(suite2.tests, 3)
-        case_results = [Failure, Skipped, type(None)]
-        for case, result in zip(suite2, case_results):
-            self.assertIsInstance(case.result, result)
+        cases = list(suite2.iterchildren(TestCase))
+        self.assertIsInstance(cases[0].result[0], Failure)
+        self.assertIsInstance(cases[1].result[0], Skipped)
+        self.assertEqual(len(cases[2].result), 0)
 
     @unittest.skipUnless(has_lxml, "lxml required to run the case")
     def test_fromfile_with_parser(self):
@@ -89,9 +90,9 @@ class Test_RealFile(unittest.TestCase):
         self.assertEqual(len(cases), 3)
         self.assertEqual(xml.name, "JUnitXmlReporter.constructor")
         self.assertEqual(xml.tests, 3)
-        case_results = [Failure, Skipped, type(None)]
-        for case, result in zip(xml, case_results):
-            self.assertIsInstance(case.result, result)
+        self.assertIsInstance(cases[0].result[0], Failure)
+        self.assertIsInstance(cases[1].result[0], Skipped)
+        self.assertEqual(len(cases[2].result), 0)
 
     def test_write_xml_withouth_testsuite_tag(self):
         suite = TestSuite()
@@ -187,8 +188,7 @@ class Test_RealFile(unittest.TestCase):
         xml = JUnitXml.fromstring(text)
         suite = next(iter(xml))
         case = next(iter(suite))
-        with self.assertRaises(JUnitXmlError):
-            result = case.result
+        self.assertEqual(len(case.result), 2)
 
     def test_write_pretty(self):
         suite1 = TestSuite()

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -76,9 +76,10 @@ class Test_RealFile(unittest.TestCase):
         self.assertEqual(len(suite2), 3)
         self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
         self.assertEqual(suite2.tests, 3)
-        case_results = [Failure, Skipped, type(None)]
-        for case, result in zip(suite2, case_results):
-            self.assertIsInstance(case.result, result)
+        cases = list(suite2.iterchildren(TestCase))
+        self.assertIsInstance(cases[0].result[0], Failure)
+        self.assertIsInstance(cases[1].result[0], Skipped)
+        self.assertEqual(len(cases[2].result), 0)
 
     def test_fromfile_without_testsuites_tag(self):
         xml = JUnitXml.fromfile(

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -424,10 +424,12 @@ class Test_TestCase(unittest.TestCase):
         case.classname = "testclassname"
         case.time = 15.123
         case.result = [Skipped()]
+        case.result[0].text = "woah skipped"
         self.assertEqual(case.name, "testname")
         self.assertEqual(case.classname, "testclassname")
         self.assertEqual(case.time, 15.123)
         self.assertIsInstance(case.result[0], Skipped)
+        self.assertEqual(case.result[0].text, "woah skipped")
 
     def test_case_init_with_attributes(self):
         case = TestCase("testname", "testclassname", 15.123)


### PR DESCRIPTION
Fix #54 