### PR TITLE
fix parsing localized float strings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.x
+    - name: Setup locales
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo update-locale
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -35,6 +35,9 @@ try:
 except NameError:
     unicode = str
 
+from locale import atof, setlocale, LC_ALL
+
+setlocale(LC_ALL, '')
 
 def write_xml(obj, filepath=None, pretty=False):
     tree = etree.ElementTree(obj._elem)
@@ -115,7 +118,7 @@ class FloatAttr(Attr):
         if result is None and isinstance(instance, (JUnitXml, TestSuite)):
             instance.update_statistics()
             result = super(FloatAttr, self).__get__(instance, cls)
-        return float(result) if result else None
+        return atof(result) if result else None
 
     def __set__(self, instance, value):
         if not (isinstance(value, float) or isinstance(value, int)):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -26,6 +26,13 @@ try:
 except ImportError:
     pass
 
+import locale
+try:
+    locale.setlocale(locale.LC_NUMERIC, 'en_US.UTF-8')
+    has_us_locale = True
+except locale.Error:
+    has_us_locale = False
+
 
 class Test_MergeSuiteCounts(unittest.TestCase):
     def test_merge_test_count(self):
@@ -94,7 +101,7 @@ class Test_JunitXml(unittest.TestCase):
     def test_fromstring_multiple_fails(self):
         text = """<testsuites>
         <testsuite errors="1" failures="0" hostname="hooch" name="pytest" skipped="1" tests="3" time="0.025" timestamp="2020-02-05T10:52:33.843536">
-        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="0.000"/>
+        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="1""" + ("," if has_us_locale else "") + """000.000"/>
         <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.000">
         <skipped message="unconditional skip" type="pytest.skip">test_x.py:11: unconditional skip</skipped>
         <error message="test teardown failure">


### PR DESCRIPTION
Currently junitparser will fail on junit report containing long test (over 1000 seconds) with time attribute set to localized float representation, which may include commas - e.g. 1,200.058. I'm attempting to fix it by:
- setting locale from environment variables
- using locale.atof(result) instead of float(result)

In tests I'm setting locale manually to 'en_US.UTF-8'. Since there's no guarantee that any specific locale exists on system,
I'm failing to testing without comma included in such case.