### PR TITLE
Remove locale sensitivity when parsing numbers, simplifies #58

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Setup locales
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo locale-gen de_DE.UTF-8
+        sudo update-locale
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -41,6 +46,7 @@ jobs:
     - name: Setup locales
       run: |
         sudo locale-gen en_US.UTF-8
+        sudo locale-gen de_DE.UTF-8
         sudo update-locale
     - name: Install dependencies
       run: |

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -35,9 +35,6 @@ try:
 except NameError:
     unicode = str
 
-from locale import atof, setlocale, LC_ALL
-
-setlocale(LC_ALL, '')
 
 def write_xml(obj, filepath=None, pretty=False):
     tree = etree.ElementTree(obj._elem)
@@ -118,7 +115,7 @@ class FloatAttr(Attr):
         if result is None and isinstance(instance, (JUnitXml, TestSuite)):
             instance.update_statistics()
             result = super(FloatAttr, self).__get__(instance, cls)
-        return atof(result) if result else None
+        return float(result.replace(',', '')) if result else None
 
     def __set__(self, instance, value):
         if not (isinstance(value, float) or isinstance(value, int)):


### PR DESCRIPTION
Assumes JUnit XML files always contain numbers formatted in C locale, optionally with thousands separator, as reported in #58. This simplifies #58 which broke junitparser when running in environments with locales that are incompatible with C or en_US (for instance de_DE). For more details, see #64.

This implementation mimics the behaviour of `atof` given a C locale (which in that situation only removes the thousands separator `,` and parses the result with `float()`).

Adds tests that C locale formatted time string is identically parsed in `en_US` and `de_DE` locals.