### PR TITLE
Support testcase tags inside testcase tags

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 from future.utils import with_metaclass
 from builtins import object
 from io import open
+import itertools
 
 try:
     from html import escape  # python 3.x
@@ -361,7 +362,12 @@ class TestSuite(Element):
         self.filepath = None
 
     def __iter__(self):
-        return super(TestSuite, self).iterchildren(TestCase)
+        return itertools.chain(
+            super(TestSuite, self).iterchildren(TestCase),
+            [case
+             for suite in super(TestSuite, self).iterchildren(TestSuite)
+             for case in suite],
+        )
 
     def __len__(self):
         return len(list(self.__iter__()))

--- a/tests/data/jenkins.xml
+++ b/tests/data/jenkins.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- according to https://llg.cubic.org/docs/junit/, <testsuite> can be child of <testsuite> -->
+<testsuites>
+   <testsuite name="JUnitXmlReporter" errors="0" tests="0" failures="0" time="0" timestamp="2013-05-24T10:23:58" />
+   <testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="1" tests="3" failures="1" time="0.006" timestamp="2013-05-24T10:23:58">
+      <properties>
+         <property name="java.vendor" value="Sun Microsystems Inc." />
+         <property name="compiler.debug" value="on" />
+         <property name="project.jdk.classpath" value="jdk.classpath.1.6" />
+      </properties>
+      <testcase classname="JUnitXmlReporter.constructor" name="should default path to an empty string" time="0.006">
+         <failure message="test failure">Assertion failed</failure>
+      </testcase>
+      <testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="1" tests="2" failures="0" time="0.000" timestamp="2013-05-24T10:23:58">
+         <testcase classname="JUnitXmlReporter.constructor" name="should default consolidate to true" time="0">
+            <skipped />
+         </testcase>
+         <testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="0" tests="1" failures="0" time="0" timestamp="2013-05-24T10:23:58">
+            <testcase classname="JUnitXmlReporter.constructor" name="should default useDotNotation to true" time="0" />
+         </testsuite>
+      </testsuite>
+   </testsuite>
+</testsuites>

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -95,6 +95,24 @@ class Test_RealFile(unittest.TestCase):
         self.assertIsInstance(cases[1].result[0], Skipped)
         self.assertEqual(len(cases[2].result), 0)
 
+    def test_fromfile_with_testsuite_in_testsuite(self):
+        xml = JUnitXml.fromfile(
+            os.path.join(os.path.dirname(__file__), "data/jenkins.xml")
+        )
+        suite1, suite2 = list(iter(xml))
+        self.assertEqual(len(list(suite1.properties())), 0)
+        self.assertEqual(len(list(suite2.properties())), 3)
+        self.assertEqual(len(suite2), 3)
+        self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
+        self.assertEqual(suite2.tests, 3)
+        direct_cases = list(suite2.iterchildren(TestCase))
+        self.assertEqual(len(direct_cases), 1)
+        self.assertIsInstance(direct_cases[0].result[0], Failure)
+        all_cases = list(suite2)
+        self.assertIsInstance(all_cases[0].result[0], Failure)
+        self.assertIsInstance(all_cases[1].result[0], Skipped)
+        self.assertEqual(len(all_cases[2].result), 0)
+
     def test_write_xml_withouth_testsuite_tag(self):
         suite = TestSuite()
         suite.name = "suite1"


### PR DESCRIPTION
According to https://llg.cubic.org/docs/junit/, `<testsuite>` can be child of `<testsuite>`. This fix allows to iterate over all TestCase leafs under a TestSuite.

I am not sure which implications this "feature" has on merging and writing xml files, as I have never used that.