### PR TITLE
Fix representation of time precision

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -290,7 +290,7 @@ class JUnitXml(Element):
         self.failures = failures
         self.errors = errors
         self.skipped = skipped
-        self.time = time
+        self.time = round(time, 3)
 
     @classmethod
     def fromstring(cls, text):
@@ -448,7 +448,7 @@ class TestSuite(Element):
         self.errors = errors
         self.failures = failures
         self.skipped = skipped
-        self.time = time
+        self.time = round(time, 3)
 
     def add_property(self, name, value):
         """Adds a property to the testsuite.


### PR DESCRIPTION
Occasionally accumulation of the time fields for testcase and testsuite elements (especially if there are several small duration tests) will result in time representation being printed with invalid precision (e.g. 0.4420000000000001)

There does not seem to be a source of truth for schema validation but the xunit-plugin for jenkins does provide this one https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd

According to the above limiting precision to 3 places seems proper)