### PR TITLE
Fix typo in cli merge

### DIFF
--- a/junitparser/cli.py
+++ b/junitparser/cli.py
@@ -12,7 +12,7 @@ def merge(paths, output):
         result += JUnitXml.fromfile(path)
 
     result.update_statistics()
-    result.write(output, to_concole=output == "-")
+    result.write(output, to_console=output == "-")
     return 0
 
 


### PR DESCRIPTION
https://github.com/weiwei/junitparser/commit/ae78dd61a1389924d51d33def488cb112f3f5f47 was good but broke the merge command in cli.py.

This fixes that. #78 