### PR TITLE
Add compare CLI command 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,7 @@ Command Line
     {merge}        command
       merge        Merge Junit XML format reports with junitparser.
       verify       Return a non-zero exit code if one of the testcases failed or errored.
+      compare      Create a new report with testcases that did not fail or error before.
 
     optional arguments:
     -h, --help     show this help message and exit
@@ -241,6 +242,20 @@ Command Line
     optional arguments:
       -h, --help  show this help message and exit
       --glob      Treat original XML path(s) as glob(s).
+
+
+.. code-block:: shell
+
+    $ junitparser compare --help
+    usage: junitparser compare [-h] before after output
+
+    positional arguments:
+      before      Path of the initial XML report to compare.
+      after       Path of the re-run XML report to compare.
+      output      Compared XML Path, setting to "-" will output console
+
+    optional arguments:
+      -h, --help  show this help message and exit
 
 Test
 ----

--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ Command Line
     {merge}        command
       merge        Merge Junit XML format reports with junitparser.
       verify       Return a non-zero exit code if one of the testcases failed or errored.
-      compare      Create a new report with testcases that did not fail or error before.
+      compare      Create a new report with testcases that passed before but fail or error now.
 
     optional arguments:
     -h, --help     show this help message and exit

--- a/junitparser/cli.py
+++ b/junitparser/cli.py
@@ -31,7 +31,7 @@ def verify(paths):
 
 
 def compare(path_before, path_after, output):
-    """Create a new report with testcases that did not fail or error before."""
+    """Create a new report with testcases that passed before but fail or error now."""
     before = JUnitXml.fromfile(path_before)
     after = JUnitXml.fromfile(path_after)
     xml = before.compare(after)
@@ -81,7 +81,7 @@ def _parser(prog_name=None):  # pragma: no cover
 
     # command: compare
     merge_parser = command_parser.add_parser(
-        "compare", help="Create a new report with testcases that did not fail or error before."
+        "compare", help="Create a new report with testcases that passed before but fail or error now."
     )
     merge_parser.add_argument("before", help="Path of the initial XML report to compare.")
     merge_parser.add_argument("after", help="Path of the re-run XML report to compare.")

--- a/junitparser/cli.py
+++ b/junitparser/cli.py
@@ -30,6 +30,15 @@ def verify(paths):
     return 0
 
 
+def compare(path_before, path_after, output):
+    """Create a new report with testcases that did not fail or error before."""
+    before = JUnitXml.fromfile(path_before)
+    after = JUnitXml.fromfile(path_after)
+    xml = before.compare(after)
+    xml.write(output, to_console=output == "-")
+    return 0
+
+
 def _parser(prog_name=None):  # pragma: no cover
     """Create the CLI arg parser."""
     parser = ArgumentParser(description="Junitparser CLI helper.", prog=prog_name)
@@ -70,6 +79,16 @@ def _parser(prog_name=None):  # pragma: no cover
     )
     merge_parser.add_argument("paths", nargs="+", help="XML path(s) of reports to verify.")
 
+    # command: compare
+    merge_parser = command_parser.add_parser(
+        "compare", help="Create a new report with testcases that did not fail or error before."
+    )
+    merge_parser.add_argument("before", help="Path of the initial XML report to compare.")
+    merge_parser.add_argument("after", help="Path of the re-run XML report to compare.")
+    merge_parser.add_argument(
+        "output", help='Compared XML Path, setting to "-" will output console'
+    )
+
     return parser
 
 
@@ -89,4 +108,6 @@ def main(args=None, prog_name=None):
             if args.paths_are_globs
             else args.paths
         )
+    if args.command == "compare":
+        return compare(args.before, args.after, args.output)
     return 255

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -300,6 +300,34 @@ class JUnitXml(Element):
         self.skipped = skipped
         self.time = round(time, 3)
 
+    def compare(self, other):
+        """Create a new report with testcases that did not fail or error in the other report."""
+        passed = []
+        for suite in self:
+            for case in suite:
+                if case.is_passed:
+                    passed.append(case)
+
+        failed = []
+        for suite in other:
+            for case in suite:
+                if not case.is_passed and not case.is_skipped:
+                    failed.append(case)
+
+        newly_failed = []
+        for f in failed:
+            for p in passed:
+                if (f.classname, f.name) == (p.classname, p.name):
+                    newly_failed.append(f)
+
+        xml = JUnitXml()
+        suite = TestSuite('newly_failed_tests')
+        suite.add_testcases(newly_failed)
+        xml.add_testsuite(suite)
+        xml.update_statistics()
+
+        return xml
+
     @classmethod
     def fromstring(cls, text):
         """Construct Junit objects from a XML string."""

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -301,7 +301,7 @@ class JUnitXml(Element):
         self.time = round(time, 3)
 
     def compare(self, other):
-        """Create a new report with testcases that did not fail or error in the other report."""
+        """Create a new report with testcases that passed in this report but fail or error in the other."""
         passed = []
         for suite in self:
             for case in suite:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from __future__ import with_statement
 
 import locale
+import os
 import unittest
 from copy import deepcopy
 from xml.etree import ElementTree as etree
@@ -268,6 +269,26 @@ class Test_JunitXml(unittest.TestCase):
         result3 = result1 + result2
         result3.update_statistics()
         self.assertEqual(result3.tests, 0)
+
+    def test_compare(self):
+        normal = JUnitXml.fromfile(
+            os.path.join(os.path.dirname(__file__), "data/normal.xml")
+        )
+        # Identical to `normal` but with a failure removed.
+        no_fails = JUnitXml.fromfile(
+            os.path.join(os.path.dirname(__file__), "data/no_fails.xml")
+        )
+        compared = normal.compare(no_fails)
+        self.assertEqual(compared.errors, 0)
+        self.assertEqual(compared.tests, 0)
+        self.assertEqual(compared.failures, 0)
+        self.assertEqual(compared.skipped, 0)
+
+        compared = no_fails.compare(normal)
+        self.assertEqual(compared.errors, 0)
+        self.assertEqual(compared.tests, 1)
+        self.assertEqual(compared.failures, 1)
+        self.assertEqual(compared.skipped, 0)
 
 
 class Test_TestSuite(unittest.TestCase):


### PR DESCRIPTION
`compare` creates a new report with testcases that did
not fail or error before, but do so in the newer report.

This is useful when you have a test suite that has a number
of failures that you cannot fix or skip (not ideal, but that's
sadly one of my own use cases) but you are nonetheless still
interested in regressions compared to previous runs.