### PR TITLE
Add JUnitXML.fromroot

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -293,9 +293,8 @@ class JUnitXml(Element):
         self.time = round(time, 3)
 
     @classmethod
-    def fromstring(cls, text):
-        """Construct Junit objects from a XML string."""
-        root_elem = etree.fromstring(text)  # nosec
+    def fromroot(cls, root_elem):
+        """Constructs Junit objects from an elementTree root element."""
         if root_elem.tag == "testsuites":
             instance = cls()
         elif root_elem.tag == "testsuite":
@@ -306,6 +305,12 @@ class JUnitXml(Element):
         return instance
 
     @classmethod
+    def fromstring(cls, text):
+        """Construct Junit objects from a XML string."""
+        root_elem = etree.fromstring(text)  # nosec
+        return cls.fromroot(root_elem)
+
+    @classmethod
     def fromfile(cls, filepath, parse_func=None):
         """Initiate the object from a report file."""
         if parse_func:
@@ -313,13 +318,7 @@ class JUnitXml(Element):
         else:
             tree = etree.parse(filepath)  # nosec
         root_elem = tree.getroot()
-        if root_elem.tag == "testsuites":
-            instance = cls()
-        elif root_elem.tag == "testsuite":
-            instance = TestSuite()
-        else:
-            raise JUnitXmlError("Invalid format.")
-        instance._elem = root_elem
+        instance = cls.fromroot(root_elem)
         instance.filepath = filepath
         return instance
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -128,6 +128,52 @@ class Test_JunitXml(unittest.TestCase):
         </testsuite>
         </testsuites>"""
         result = JUnitXml.fromstring(text)
+        self.assertIsInstance(result, JUnitXml)
+        self.assertEqual(result.errors, 1)
+        self.assertEqual(result.skipped, 1)
+        suite = list(iter(result))[0]
+        cases = list(iter(suite))
+        self.assertEqual(len(cases[0].result), 0)
+        self.assertEqual(len(cases[1].result), 2)
+        text = cases[1].result[1].text
+        self.assertTrue("@pytest.fixture" in text)
+
+    def test_fromroot_testsuite(self):
+        text = """
+        <testsuite errors="1" failures="0" hostname="hooch" name="pytest" skipped="1" tests="3" time="0.025" timestamp="2020-02-05T10:52:33.843536">
+        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="0.000"/>
+        <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.000">
+        <skipped message="unconditional skip" type="pytest.skip">test_x.py:11: unconditional skip</skipped>
+        <error message="test teardown failure">
+        @pytest.fixture(scope="module") def compb(): yield > raise PermissionError E PermissionError test_x.py:6: PermissionError
+        </error>
+        </testcase>
+        </testsuite>"""
+        root_elemt = etree.fromstring(text)
+        result = JUnitXml.fromroot(root_elemt)
+        self.assertIsInstance(result, TestSuite)
+        self.assertEqual(result.errors, 1)
+        self.assertEqual(result.skipped, 1)
+        cases = list(iter(result))
+        self.assertEqual(len(cases[0].result), 0)
+        self.assertEqual(len(cases[1].result), 2)
+        text = cases[1].result[1].text
+        self.assertTrue("@pytest.fixture" in text)
+
+    def test_fromroot_testsuites(self):
+        text = """<testsuites>
+        <testsuite errors="1" failures="0" hostname="hooch" name="pytest" skipped="1" tests="3" time="0.025" timestamp="2020-02-05T10:52:33.843536">
+        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="0.000"/>
+        <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.000">
+        <skipped message="unconditional skip" type="pytest.skip">test_x.py:11: unconditional skip</skipped>
+        <error message="test teardown failure">
+        @pytest.fixture(scope="module") def compb(): yield > raise PermissionError E PermissionError test_x.py:6: PermissionError
+        </error>
+        </testcase>
+        </testsuite>
+        </testsuites>"""
+        root_elemt = etree.fromstring(text)
+        result = JUnitXml.fromroot(root_elemt)
         self.assertEqual(result.errors, 1)
         self.assertEqual(result.skipped, 1)
         suite = list(iter(result))[0]


### PR DESCRIPTION
This allows to create an `JUnitXML` instance from an `ElementTree` root element, just like parsing a file.

Use case: I have parsed a file into an `ElementTree` and performed some operations on that tree. From the final tree, I want to create the `JUnitXML` object, identical to `JUnitXML.fromfile` and `JUnitXML.fromstring`.

There is some extra logic in `JUnitXML.fromfile` and `JUnitXML.fromstring`, that is not in `Element.fromelem`.