### PR TITLE
junitparser.py: Remove `skipped` attribute from `testsuites` element

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -231,7 +231,6 @@ class JUnitXml(Element):
         tests: total number of tests
         failures: number of failed cases
         errors: number of cases with errors
-        skipped: number of skipped cases
     """
 
     _tag = "testsuites"
@@ -240,12 +239,12 @@ class JUnitXml(Element):
     tests = IntAttr()
     failures = IntAttr()
     errors = IntAttr()
-    skipped = IntAttr()
 
     def __init__(self, name=None):
         super(JUnitXml, self).__init__(self._tag)
         self.filepath = None
         self.name = name
+        self.skipped = 0
 
     def __iter__(self):
         return super(JUnitXml, self).iterchildren(TestSuite)


### PR DESCRIPTION
The presence of the "skipped" attribute in the "testsuites" element makes validation against the junit/xunit2 schemas fail. Remove it so that xml output is compliant.

See schemas: [Jenkins xunit plugin](https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd#L139-L143) or [pytest](https://github.com/pytest-dev/pytest/blob/main/testing/example_scripts/junit-10.xsd#L139-L143), as well as the [JUnit spec](https://www.ibm.com/docs/en/developer-for-zos/14.2?topic=formats-junit-xml-format).

Fixes #100.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>