### PR TITLE
junitparser.py: Fix removing items with xml.etree

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -710,7 +710,7 @@ class TestCase(Element):
     @result.setter
     def result(self, value):
         # First remove all existing results
-        for entry in self:
+        for entry in self.result:
             if any(isinstance(entry, r) for r in POSSIBLE_RESULTS):
                 self.remove(entry)
         for entry in value:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -507,6 +507,24 @@ class Test_TestCase(unittest.TestCase):
         self.assertEqual(case.name, "testname")
         self.assertEqual(len(case.result), 2)
 
+    def test_multi_results(self):
+        case = TestCase("testname", "testclassname")
+        err = Error("err msg", "err_type")
+        fail1 = Failure("fail msg 1", "fail_type")
+        fail2 = Failure("fail msg 2", "fail_type")
+        fail3 = Failure("fail msg 3", "fail_type")
+        fail4 = Failure("fail msg 4", "fail_type")
+        case.result += [err]
+        self.assertEqual(len(case.result), 1)
+        case.result += [fail1]
+        self.assertEqual(len(case.result), 2)
+        case.result += [fail2]
+        self.assertEqual(len(case.result), 3)
+        case.result += [fail3]
+        self.assertEqual(len(case.result), 4)
+        case.result += [fail4]
+        self.assertEqual(len(case.result), 5)
+
     def test_case_attributes(self):
         case = TestCase()
         case.name = "testname"

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -496,14 +496,16 @@ class Test_TestCase(unittest.TestCase):
         self.assertEqual(case.system_out, "System out")
         self.assertEqual(case.system_err, "System err")
 
-    def test_illegal_xml_multi_results(self):
+    def test_xml_multi_results(self):
         text = """<testcase name="testname">
         <failure message="failure message" type="FailureType"/>
         <skipped message="skipped message" type="FailureType"/>
         </testcase>
         """
         case = TestCase.fromstring(text)
-        self.assertRaises(JUnitXmlError)
+        # no assertion raised
+        self.assertEqual(case.name, "testname")
+        self.assertEqual(len(case.result), 2)
 
     def test_case_attributes(self):
         case = TestCase()


### PR DESCRIPTION
The iteration in TestCase.result.setter did not work properly when using xml.etree instead of lxml.etree. This was because the Element.remove() method was being invoked while iterating the elements, and apparently xml.etree does not support that.
Instead, use a prepopulated lits of Elements to iterate and remove.

Fixes #99.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>