### PR TITLE
Rework CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.x"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.5]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup locales
@@ -44,9 +44,9 @@ jobs:
     needs: build-test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Setup locales
@@ -74,9 +74,9 @@ jobs:
     needs: coverage-lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Build packages
@@ -86,7 +86,7 @@ jobs:
         python setup.py sdist bdist_wheel
     - name: Publish to pypi
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    # Python version < 3.7 requires ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
         pip install lxml
         pytest
 
-  publish:
+  coverage-lint:
+    needs: build-test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -68,8 +69,17 @@ jobs:
       run: |
         coverage run -m pytest
         bash <(curl -s https://codecov.io/bash)
+
+  package-publish:
+    needs: coverage-lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
     - name: Build packages
-      if: startsWith(github.ref, 'refs/tags')
       run: |
         pip install setuptools wheel
         python setup.py sdist bdist_wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
         python-version: 3.x
     - name: Build packages
       run: |
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install setuptools wheel
         python setup.py sdist bdist_wheel
     - name: Publish to pypi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
     - name: Test
       run: |
         pytest
+    - name: Test with lxml
+      run: |
+        pip install lxml
+        pytest
 
   publish:
     runs-on: ubuntu-latest

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -33,20 +33,20 @@ except ImportError:
 
 try:
     from lxml import etree as expected_lxml_etree
-    used_xml = "lxml"
+    has_lxml = True
 except ImportError:
     from xml.etree import ElementTree as expected_xml_etree
-    used_xml = "xml"
+    has_lxml = False
 
 
 class Test_XmlPackage(unittest.TestCase):
 
-    @unittest.skipIf(used_xml != "xml", "xml package is not expected to be used")
+    @unittest.skipIf(has_lxml, "xml package is used unless lxml is installed")
     def test_xml_etree(self):
         from junitparser.junitparser import etree as actual_etree
         self.assertEqual(actual_etree, expected_xml_etree)
 
-    @unittest.skipIf(used_xml != "lxml", "lxml package is not installed")
+    @unittest.skipUnless(has_lxml, "lxml package has to be installed")
     def test_lxml_etree(self):
         from junitparser.junitparser import etree as actual_etree
         self.assertEqual(actual_etree, expected_lxml_etree)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -31,6 +31,27 @@ except ImportError:
     pass
 
 
+try:
+    from lxml import etree as expected_lxml_etree
+    used_xml = "lxml"
+except ImportError:
+    from xml.etree import ElementTree as expected_xml_etree
+    used_xml = "xml"
+
+
+class Test_XmlPackage(unittest.TestCase):
+
+    @unittest.skipIf(used_xml != "xml", "xml package is not expected to be used")
+    def test_xml_etree(self):
+        from junitparser.junitparser import etree as actual_etree
+        self.assertEqual(actual_etree, expected_xml_etree)
+
+    @unittest.skipIf(used_xml != "lxml", "lxml package is not installed")
+    def test_lxml_etree(self):
+        from junitparser.junitparser import etree as actual_etree
+        self.assertEqual(actual_etree, expected_lxml_etree)
+
+
 class Test_MergeSuiteCounts(unittest.TestCase):
     def test_merge_test_count(self):
         text1 = """<testsuite name="suitename1" tests="2" failures="1">


### PR DESCRIPTION
Reworks the CI:
- fixes the CI now that `ubuntu-latest` moved to `ubuntu-22.04` (Python 2.7 is not available for Ubuntu 22.04)
- tests junitparser with lxml in `build-test` step
- always builds package, not only for tags
- remove Python 3.5, add 3.6 to 3.11
- upgrades action versions