### PR TITLE
Convert to pytest

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,11 @@ import os
 import pytest
 from junitparser.cli import verify
 
-@pytest.mark.parametrize("file, expected_exitcode", [
-        ("data/jenkins.xml", 1),
-        ("data/no_fails.xml", 0),
-        ("data/normal.xml", 1)])
+
+@pytest.mark.parametrize(
+    "file, expected_exitcode",
+    [("data/jenkins.xml", 1), ("data/no_fails.xml", 0), ("data/normal.xml", 1)],
+)
 def test_verify(file, expected_exitcode):
     path = os.path.join(os.path.dirname(__file__), file)
     assert verify([path]) == expected_exitcode

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import os
-import unittest
-
+import pytest
 from junitparser.cli import verify
 
-
-class Test_Cli(unittest.TestCase):
-    def test_verify(self):
-        files_expectedexitcodes = {
-            "data/jenkins.xml": 1,
-            "data/no_fails.xml": 0,
-            "data/normal.xml": 1,
-        }
-        for file, expected_exitcode in files_expectedexitcodes.items():
-            path = os.path.join(os.path.dirname(__file__), file)
-            self.assertEqual(verify([path]), expected_exitcode)
+@pytest.mark.parametrize("file, expected_exitcode", [
+        ("data/jenkins.xml", 1),
+        ("data/no_fails.xml", 0),
+        ("data/normal.xml", 1)])
+def test_verify(file, expected_exitcode):
+    path = os.path.join(os.path.dirname(__file__), file)
+    assert verify([path]) == expected_exitcode

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -29,7 +29,7 @@ except ImportError:
 def tmpfile():
     import tempfile
 
-    tmp = tempfile.mktemp(suffix=".xml")
+    tmp = tempfile.mkstemp(suffix=".xml")
     yield tmp
     if os.path.exists(tmp):
         os.remove(tmp)
@@ -121,7 +121,7 @@ def test_file_is_not_xml(tmpfile):
     with open(tmpfile, "w") as f:
         f.write(text)
     with pytest.raises(Exception):
-        xml = JUnitXml.fromfile(tmpfile)
+        JUnitXml.fromfile(tmpfile)
         # Raises lxml.etree.XMLSyntaxError
 
 
@@ -130,7 +130,7 @@ def test_illegal_xml_file(tmpfile):
     with open(tmpfile, "w") as f:
         f.write(text)
     with pytest.raises(JUnitXmlError):
-        xml = JUnitXml.fromfile(tmpfile)
+        JUnitXml.fromfile(tmpfile)
 
 
 def test_write(tmpfile):

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -35,7 +35,7 @@ def tmpfile():
         os.remove(tmp)
 
 
-def test_fromfile(tmpfile):
+def test_fromfile():
     xml = JUnitXml.fromfile(os.path.join(os.path.dirname(__file__), "data/normal.xml"))
     suite1, suite2 = list(iter(xml))
     assert len(list(suite1.properties())) == 0
@@ -50,7 +50,7 @@ def test_fromfile(tmpfile):
 
 
 @pytest.mark.skipif(not has_lxml, reason="lxml required to run the case")
-def test_fromfile_with_parser(tmpfile):
+def test_fromfile_with_parser():
     def parse_func(file_path):
         xml_parser = XMLParser(huge_tree=True)
         return parse(file_path, xml_parser)
@@ -71,7 +71,7 @@ def test_fromfile_with_parser(tmpfile):
     assert len(cases[2].result) == 0
 
 
-def test_fromfile_without_testsuites_tag(tmpfile):
+def test_fromfile_without_testsuites_tag():
     xml = JUnitXml.fromfile(
         os.path.join(os.path.dirname(__file__), "data/no_suites_tag.xml")
     )
@@ -86,7 +86,7 @@ def test_fromfile_without_testsuites_tag(tmpfile):
     assert len(cases[2].result) == 0
 
 
-def test_fromfile_with_testsuite_in_testsuite(tmpfile):
+def test_fromfile_with_testsuite_in_testsuite():
     xml = JUnitXml.fromfile(os.path.join(os.path.dirname(__file__), "data/jenkins.xml"))
     suite1, suite2 = list(iter(xml))
     assert len(list(suite1.properties())) == 0
@@ -148,7 +148,7 @@ def test_write(tmpfile):
     assert "case1" in text
 
 
-def test_write_noarg(tmpfile):
+def test_write_noarg():
     suite1 = TestSuite()
     suite1.name = "suite1"
     case1 = TestCase()
@@ -190,7 +190,7 @@ def test_read_written_xml(tmpfile):
     assert case.name == "用例1"
 
 
-def test_multi_results_in_case(tmpfile):
+def test_multi_results_in_case():
     # Has to be a binary string to include xml declarations.
     text = b"""<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-import unittest
+import pytest
 from junitparser import (
     TestCase,
     TestSuite,
@@ -19,175 +19,171 @@ from junitparser import (
 
 try:
     from lxml.etree import XMLParser, parse
-
     has_lxml = True
 except ImportError:
     has_lxml = False
 
-from io import open
 
+@pytest.fixture(scope="module")
+def tmpfile():
+    import tempfile
 
-class Test_RealFile(unittest.TestCase):
-    def setUp(self):
-        import tempfile
+    tmp = tempfile.mktemp(suffix=".xml")
+    yield tmp
+    if os.path.exists(tmp):
+        os.remove(tmp)
 
-        self.tmp = tempfile.mktemp(suffix=".xml")
+def test_fromfile(tmpfile):
+    xml = JUnitXml.fromfile(
+        os.path.join(os.path.dirname(__file__), "data/normal.xml")
+    )
+    suite1, suite2 = list(iter(xml))
+    assert len(list(suite1.properties())) == 0
+    assert len(list(suite2.properties())) == 3
+    assert len(suite2) == 3
+    assert suite2.name == "JUnitXmlReporter.constructor"
+    assert suite2.tests == 3
+    cases = list(suite2.iterchildren(TestCase))
+    assert isinstance(cases[0].result[0], Failure)
+    assert isinstance(cases[1].result[0], Skipped)
+    assert len(cases[2].result) == 0
 
-    def tearDown(self):
-        if os.path.exists(self.tmp):
-            os.remove(self.tmp)
+@pytest.mark.skipif(not has_lxml, reason="lxml required to run the case")
+def test_fromfile_with_parser(tmpfile):
+    def parse_func(file_path):
+        xml_parser = XMLParser(huge_tree=True)
+        return parse(file_path, xml_parser)
 
-    def test_fromfile(self):
-        xml = JUnitXml.fromfile(
-            os.path.join(os.path.dirname(__file__), "data/normal.xml")
-        )
-        suite1, suite2 = list(iter(xml))
-        self.assertEqual(len(list(suite1.properties())), 0)
-        self.assertEqual(len(list(suite2.properties())), 3)
-        self.assertEqual(len(suite2), 3)
-        self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
-        self.assertEqual(suite2.tests, 3)
-        cases = list(suite2.iterchildren(TestCase))
-        self.assertIsInstance(cases[0].result[0], Failure)
-        self.assertIsInstance(cases[1].result[0], Skipped)
-        self.assertEqual(len(cases[2].result), 0)
+    xml = JUnitXml.fromfile(
+        os.path.join(os.path.dirname(__file__), "data/normal.xml"),
+        parse_func=parse_func,
+    )
+    suite1, suite2 = list(iter(xml))
+    assert len(list(suite1.properties())) == 0
+    assert len(list(suite2.properties())) == 3
+    assert len(suite2) == 3
+    assert suite2.name == "JUnitXmlReporter.constructor"
+    assert suite2.tests == 3
+    cases = list(suite2.iterchildren(TestCase))
+    assert isinstance(cases[0].result[0], Failure)
+    assert isinstance(cases[1].result[0], Skipped)
+    assert len(cases[2].result) == 0
 
-    @unittest.skipUnless(has_lxml, "lxml required to run the case")
-    def test_fromfile_with_parser(self):
-        def parse_func(file_path):
-            xml_parser = XMLParser(huge_tree=True)
-            return parse(file_path, xml_parser)
+def test_fromfile_without_testsuites_tag(tmpfile):
+    xml = JUnitXml.fromfile(
+        os.path.join(os.path.dirname(__file__), "data/no_suites_tag.xml")
+    )
+    cases = list(iter(xml))
+    properties = list(iter(xml.properties()))
+    assert len(properties) == 3
+    assert len(cases) == 3
+    assert xml.name == "JUnitXmlReporter.constructor"
+    assert xml.tests == 3
+    assert isinstance(cases[0].result[0], Failure)
+    assert isinstance(cases[1].result[0], Skipped)
+    assert len(cases[2].result) == 0
 
-        xml = JUnitXml.fromfile(
-            os.path.join(os.path.dirname(__file__), "data/normal.xml"),
-            parse_func=parse_func,
-        )
-        suite1, suite2 = list(iter(xml))
-        self.assertEqual(len(list(suite1.properties())), 0)
-        self.assertEqual(len(list(suite2.properties())), 3)
-        self.assertEqual(len(suite2), 3)
-        self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
-        self.assertEqual(suite2.tests, 3)
-        cases = list(suite2.iterchildren(TestCase))
-        self.assertIsInstance(cases[0].result[0], Failure)
-        self.assertIsInstance(cases[1].result[0], Skipped)
-        self.assertEqual(len(cases[2].result), 0)
+def test_fromfile_with_testsuite_in_testsuite(tmpfile):
+    xml = JUnitXml.fromfile(
+        os.path.join(os.path.dirname(__file__), "data/jenkins.xml")
+    )
+    suite1, suite2 = list(iter(xml))
+    assert len(list(suite1.properties())) == 0
+    assert len(list(suite2.properties())) == 3
+    assert len(suite2) == 3
+    assert suite2.name == "JUnitXmlReporter.constructor"
+    assert suite2.tests == 3
+    direct_cases = list(suite2.iterchildren(TestCase))
+    assert len(direct_cases) == 1
+    assert isinstance(direct_cases[0].result[0], Failure)
+    all_cases = list(suite2)
+    assert isinstance(all_cases[0].result[0], Failure)
+    assert isinstance(all_cases[1].result[0], Skipped)
+    assert len(all_cases[2].result) == 0
 
-    def test_fromfile_without_testsuites_tag(self):
-        xml = JUnitXml.fromfile(
-            os.path.join(os.path.dirname(__file__), "data/no_suites_tag.xml")
-        )
-        cases = list(iter(xml))
-        properties = list(iter(xml.properties()))
-        self.assertEqual(len(properties), 3)
-        self.assertEqual(len(cases), 3)
-        self.assertEqual(xml.name, "JUnitXmlReporter.constructor")
-        self.assertEqual(xml.tests, 3)
-        self.assertIsInstance(cases[0].result[0], Failure)
-        self.assertIsInstance(cases[1].result[0], Skipped)
-        self.assertEqual(len(cases[2].result), 0)
+def test_write_xml_without_testsuite_tag(tmpfile):
+    suite = TestSuite()
+    suite.name = "suite1"
+    case = TestCase()
+    case.name = "case1"
+    suite.add_testcase(case)
+    suite.write(tmpfile)
+    with open(tmpfile) as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "case1" in text
 
-    def test_fromfile_with_testsuite_in_testsuite(self):
-        xml = JUnitXml.fromfile(
-            os.path.join(os.path.dirname(__file__), "data/jenkins.xml")
-        )
-        suite1, suite2 = list(iter(xml))
-        self.assertEqual(len(list(suite1.properties())), 0)
-        self.assertEqual(len(list(suite2.properties())), 3)
-        self.assertEqual(len(suite2), 3)
-        self.assertEqual(suite2.name, "JUnitXmlReporter.constructor")
-        self.assertEqual(suite2.tests, 3)
-        direct_cases = list(suite2.iterchildren(TestCase))
-        self.assertEqual(len(direct_cases), 1)
-        self.assertIsInstance(direct_cases[0].result[0], Failure)
-        all_cases = list(suite2)
-        self.assertIsInstance(all_cases[0].result[0], Failure)
-        self.assertIsInstance(all_cases[1].result[0], Skipped)
-        self.assertEqual(len(all_cases[2].result), 0)
+def test_file_is_not_xml(tmpfile):
+    text = "Not really an xml file"
+    with open(tmpfile, "w") as f:
+        f.write(text)
+    with pytest.raises(Exception):
+        xml = JUnitXml.fromfile(tmpfile)
+        # Raises lxml.etree.XMLSyntaxError
 
-    def test_write_xml_withouth_testsuite_tag(self):
-        suite = TestSuite()
-        suite.name = "suite1"
-        case = TestCase()
-        case.name = "case1"
-        suite.add_testcase(case)
-        suite.write(self.tmp)
-        with open(self.tmp) as f:
-            text = f.read()
-        self.assertIn("suite1", text)
-        self.assertIn("case1", text)
+def test_illegal_xml_file(tmpfile):
+    text = "<some></some>"
+    with open(tmpfile, "w") as f:
+        f.write(text)
+    with pytest.raises(JUnitXmlError):
+        xml = JUnitXml.fromfile(tmpfile)
 
-    def test_file_is_not_xml(self):
-        text = "Not really an xml file"
-        with open(self.tmp, "w") as f:
-            f.write(text)
-        with self.assertRaises(Exception):
-            xml = JUnitXml.fromfile(self.tmp)
-            # Raises lxml.etree.XMLSyntaxError
+def test_write(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "case1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    with open(tmpfile) as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "case1" in text
 
-    def test_illegal_xml_file(self):
-        text = "<some></some>"
-        with open(self.tmp, "w") as f:
-            f.write(text)
-        with self.assertRaises(JUnitXmlError):
-            xml = JUnitXml.fromfile(self.tmp)
+def test_write_noarg(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "case1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    with pytest.raises(JUnitXmlError):
+        result.write()
 
-    def test_write(self):
-        suite1 = TestSuite()
-        suite1.name = "suite1"
-        case1 = TestCase()
-        case1.name = "case1"
-        suite1.add_testcase(case1)
-        result = JUnitXml()
-        result.add_testsuite(suite1)
-        result.write(self.tmp)
-        with open(self.tmp) as f:
-            text = f.read()
-        self.assertIn("suite1", text)
-        self.assertIn("case1", text)
+def test_write_nonascii(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    with open(tmpfile, encoding="utf-8") as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "用例1" in text
 
-    def test_write_noarg(self):
-        suite1 = TestSuite()
-        suite1.name = "suite1"
-        case1 = TestCase()
-        case1.name = "case1"
-        suite1.add_testcase(case1)
-        result = JUnitXml()
-        result.add_testsuite(suite1)
-        with self.assertRaises(JUnitXmlError):
-            result.write()
+def test_read_written_xml(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    xml = JUnitXml.fromfile(tmpfile)
+    suite = next(iter(xml))
+    case = next(iter(suite))
+    assert case.name == "用例1"
 
-    def test_write_nonascii(self):
-        suite1 = TestSuite()
-        suite1.name = "suite1"
-        case1 = TestCase()
-        case1.name = "用例1"
-        suite1.add_testcase(case1)
-        result = JUnitXml()
-        result.add_testsuite(suite1)
-        result.write(self.tmp)
-        with open(self.tmp, encoding="utf-8") as f:
-            text = f.read()
-        self.assertIn("suite1", text)
-        self.assertIn("用例1", text)
-
-    def test_read_written_xml(self):
-        suite1 = TestSuite()
-        suite1.name = "suite1"
-        case1 = TestCase()
-        case1.name = "用例1"
-        suite1.add_testcase(case1)
-        result = JUnitXml()
-        result.add_testsuite(suite1)
-        result.write(self.tmp)
-        xml = JUnitXml.fromfile(self.tmp)
-        suite = next(iter(xml))
-        case = next(iter(suite))
-        self.assertEqual(case.name, "用例1")
-
-    def test_multi_results_in_case(self):
-        # Has to be a binary string to include xml declarations.
-        text = b"""<?xml version="1.0" encoding="UTF-8"?>
+def test_multi_results_in_case(tmpfile):
+    # Has to be a binary string to include xml declarations.
+    text = b"""<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
    <testsuite name="JUnitXmlReporter.constructor">
       <testcase classname="JUnitXmlReporter.constructor" name="should default path to an empty string" time="0.006">
@@ -196,21 +192,21 @@ class Test_RealFile(unittest.TestCase):
       </testcase>
    </testsuite>
 </testsuites>"""
-        xml = JUnitXml.fromstring(text)
-        suite = next(iter(xml))
-        case = next(iter(suite))
-        self.assertEqual(len(case.result), 2)
+    xml = JUnitXml.fromstring(text)
+    suite = next(iter(xml))
+    case = next(iter(suite))
+    assert len(case.result) == 2
 
-    def test_write_pretty(self):
-        suite1 = TestSuite()
-        suite1.name = "suite1"
-        case1 = TestCase()
-        case1.name = "用例1"
-        suite1.add_testcase(case1)
-        result = JUnitXml()
-        result.add_testsuite(suite1)
-        result.write(self.tmp, pretty=True)
-        xml = JUnitXml.fromfile(self.tmp)
-        suite = next(iter(xml))
-        case = next(iter(suite))
-        self.assertEqual(case.name, "用例1")
+def test_write_pretty(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile, pretty=True)
+    xml = JUnitXml.fromfile(tmpfile)
+    suite = next(iter(xml))
+    case = next(iter(suite))
+    assert case.name == "用例1"

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -29,8 +29,9 @@ except ImportError:
 def tmpfile():
     import tempfile
 
-    tmp = tempfile.mkstemp(suffix=".xml")
+    fd, tmp = tempfile.mkstemp(suffix=".xml")
     yield tmp
+    os.close(fd)
     if os.path.exists(tmp):
         os.remove(tmp)
 

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -19,6 +19,7 @@ from junitparser import (
 
 try:
     from lxml.etree import XMLParser, parse
+
     has_lxml = True
 except ImportError:
     has_lxml = False
@@ -33,10 +34,9 @@ def tmpfile():
     if os.path.exists(tmp):
         os.remove(tmp)
 
+
 def test_fromfile(tmpfile):
-    xml = JUnitXml.fromfile(
-        os.path.join(os.path.dirname(__file__), "data/normal.xml")
-    )
+    xml = JUnitXml.fromfile(os.path.join(os.path.dirname(__file__), "data/normal.xml"))
     suite1, suite2 = list(iter(xml))
     assert len(list(suite1.properties())) == 0
     assert len(list(suite2.properties())) == 3
@@ -47,6 +47,7 @@ def test_fromfile(tmpfile):
     assert isinstance(cases[0].result[0], Failure)
     assert isinstance(cases[1].result[0], Skipped)
     assert len(cases[2].result) == 0
+
 
 @pytest.mark.skipif(not has_lxml, reason="lxml required to run the case")
 def test_fromfile_with_parser(tmpfile):
@@ -69,6 +70,7 @@ def test_fromfile_with_parser(tmpfile):
     assert isinstance(cases[1].result[0], Skipped)
     assert len(cases[2].result) == 0
 
+
 def test_fromfile_without_testsuites_tag(tmpfile):
     xml = JUnitXml.fromfile(
         os.path.join(os.path.dirname(__file__), "data/no_suites_tag.xml")
@@ -83,10 +85,9 @@ def test_fromfile_without_testsuites_tag(tmpfile):
     assert isinstance(cases[1].result[0], Skipped)
     assert len(cases[2].result) == 0
 
+
 def test_fromfile_with_testsuite_in_testsuite(tmpfile):
-    xml = JUnitXml.fromfile(
-        os.path.join(os.path.dirname(__file__), "data/jenkins.xml")
-    )
+    xml = JUnitXml.fromfile(os.path.join(os.path.dirname(__file__), "data/jenkins.xml"))
     suite1, suite2 = list(iter(xml))
     assert len(list(suite1.properties())) == 0
     assert len(list(suite2.properties())) == 3
@@ -101,6 +102,7 @@ def test_fromfile_with_testsuite_in_testsuite(tmpfile):
     assert isinstance(all_cases[1].result[0], Skipped)
     assert len(all_cases[2].result) == 0
 
+
 def test_write_xml_without_testsuite_tag(tmpfile):
     suite = TestSuite()
     suite.name = "suite1"
@@ -113,6 +115,7 @@ def test_write_xml_without_testsuite_tag(tmpfile):
     assert "suite1" in text
     assert "case1" in text
 
+
 def test_file_is_not_xml(tmpfile):
     text = "Not really an xml file"
     with open(tmpfile, "w") as f:
@@ -121,12 +124,14 @@ def test_file_is_not_xml(tmpfile):
         xml = JUnitXml.fromfile(tmpfile)
         # Raises lxml.etree.XMLSyntaxError
 
+
 def test_illegal_xml_file(tmpfile):
     text = "<some></some>"
     with open(tmpfile, "w") as f:
         f.write(text)
     with pytest.raises(JUnitXmlError):
         xml = JUnitXml.fromfile(tmpfile)
+
 
 def test_write(tmpfile):
     suite1 = TestSuite()
@@ -142,6 +147,7 @@ def test_write(tmpfile):
     assert "suite1" in text
     assert "case1" in text
 
+
 def test_write_noarg(tmpfile):
     suite1 = TestSuite()
     suite1.name = "suite1"
@@ -152,6 +158,7 @@ def test_write_noarg(tmpfile):
     result.add_testsuite(suite1)
     with pytest.raises(JUnitXmlError):
         result.write()
+
 
 def test_write_nonascii(tmpfile):
     suite1 = TestSuite()
@@ -167,6 +174,7 @@ def test_write_nonascii(tmpfile):
     assert "suite1" in text
     assert "用例1" in text
 
+
 def test_read_written_xml(tmpfile):
     suite1 = TestSuite()
     suite1.name = "suite1"
@@ -180,6 +188,7 @@ def test_read_written_xml(tmpfile):
     suite = next(iter(xml))
     case = next(iter(suite))
     assert case.name == "用例1"
+
 
 def test_multi_results_in_case(tmpfile):
     # Has to be a binary string to include xml declarations.
@@ -196,6 +205,7 @@ def test_multi_results_in_case(tmpfile):
     suite = next(iter(xml))
     case = next(iter(suite))
     assert len(case.result) == 2
+
 
 def test_write_pretty(tmpfile):
     suite1 = TestSuite()

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -36,10 +36,13 @@ class Test_XmlPackage:
     @pytest.mark.skipif(has_lxml, reason="xml package is used unless lxml is installed")
     def test_xml_etree(self):
         from junitparser.junitparser import etree as actual_etree
+
         assert actual_etree == expected_xml_etree
+
     @pytest.mark.skipif(not has_lxml, reason="lxml package has to be installed")
     def test_lxml_etree(self):
         from junitparser.junitparser import etree as actual_etree
+
         assert actual_etree == expected_lxml_etree
 
 
@@ -87,12 +90,12 @@ class Test_MergeSuiteCounts:
         assert combined_suites.skipped == 1
 
 
-
 @pytest.fixture()
 def locale_fixture():
     old_locale = locale.getlocale(locale.LC_NUMERIC)
     yield
     locale.setlocale(locale.LC_NUMERIC, old_locale)
+
 
 class Locale:
     @pytest.mark.parametrize("loc", ["", "en_US.UTF-8", "de_DE.UTF-8"])
@@ -132,7 +135,6 @@ class Test_JunitXml:
         result = JUnitXml.fromstring(text)
         assert len(result) == 1
         assert result.time == 0
-
 
     def test_fromstring_multiple_fails(self):
         text = """<testsuites>
@@ -657,7 +659,10 @@ class Test_TestCase:
     def test_result_attrs(self):
         res1 = Failure("A")
         # NOTE: lxml gives spaceless result
-        assert res1.tostring() in [b'<failure message="A" />', b'<failure message="A"/>']
+        assert res1.tostring() in [
+            b'<failure message="A" />',
+            b'<failure message="A"/>',
+        ]
 
     def test_add_child_element(self):
         class CustomElement(Element):
@@ -669,7 +674,10 @@ class Test_TestCase:
         custom = CustomElement()
         testcase.append(custom)
 
-        assert testcase.tostring() in [b"<testcase><custom /></testcase>", b"<testcase><custom/></testcase>"]
+        assert testcase.tostring() in [
+            b"<testcase><custom /></testcase>",
+            b"<testcase><custom/></testcase>",
+        ]
 
     def test_case_is_skipped(self):
         case = TestCase()
@@ -689,11 +697,11 @@ class Test_TestCase:
         assert not case.is_skipped
         assert not case.is_passed
 
+
 class Test_Properties:
     def test_property_repr1(self):
         prop1 = Property("prop1", "1")
         assert prop1.__repr__() == '<Element \'property\' name="prop1" value="1">'
-
 
     def test_property_repr2(self):
         prop1 = TestSuite()

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -97,7 +97,7 @@ def locale_fixture():
     locale.setlocale(locale.LC_NUMERIC, old_locale)
 
 
-class Locale:
+class Test_Locale:
     @pytest.mark.parametrize("loc", ["", "en_US.UTF-8", "de_DE.UTF-8"])
     def test_fromstring_numbers_locale_insensitive(self, loc, locale_fixture):
         "Case relies on that LC_ALL is set in the console."

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import locale
-import unittest
 from copy import deepcopy
 from xml.etree import ElementTree as etree
+import pytest
 
 from junitparser import (
     TestCase,
@@ -32,21 +32,18 @@ except ImportError:
     has_lxml = False
 
 
-class Test_XmlPackage(unittest.TestCase):
-    @unittest.skipIf(has_lxml, "xml package is used unless lxml is installed")
+class Test_XmlPackage:
+    @pytest.mark.skipif(has_lxml, reason="xml package is used unless lxml is installed")
     def test_xml_etree(self):
         from junitparser.junitparser import etree as actual_etree
-
-        self.assertEqual(actual_etree, expected_xml_etree)
-
-    @unittest.skipUnless(has_lxml, "lxml package has to be installed")
+        assert actual_etree == expected_xml_etree
+    @pytest.mark.skipif(not has_lxml, reason="lxml package has to be installed")
     def test_lxml_etree(self):
         from junitparser.junitparser import etree as actual_etree
+        assert actual_etree == expected_lxml_etree
 
-        self.assertEqual(actual_etree, expected_lxml_etree)
 
-
-class Test_MergeSuiteCounts(unittest.TestCase):
+class Test_MergeSuiteCounts:
     def test_merge_test_count(self):
         text1 = """<testsuite name="suitename1" tests="2" failures="1">
         <testcase name="testname1"><failure message="failed"/></testcase>
@@ -63,9 +60,9 @@ class Test_MergeSuiteCounts(unittest.TestCase):
         combined_suites = JUnitXml()
         combined_suites += test_suite1
         combined_suites += test_suite2
-        self.assertEqual(combined_suites.tests, 4)
-        self.assertEqual(combined_suites.failures, 1)
-        self.assertEqual(combined_suites.skipped, 1)
+        assert combined_suites.tests == 4
+        assert combined_suites.failures == 1
+        assert combined_suites.skipped == 1
 
     def test_merge_same_suite(self):
         text1 = """<testsuite name="suitename1" tests="2" failures="1">
@@ -84,13 +81,39 @@ class Test_MergeSuiteCounts(unittest.TestCase):
         combined_suites += test_suite1
         combined_suites += test_suite2
         suites = list(suite for suite in combined_suites)
-        self.assertEqual(len(suites), 1)
-        self.assertEqual(combined_suites.tests, 4)
-        self.assertEqual(combined_suites.failures, 1)
-        self.assertEqual(combined_suites.skipped, 1)
+        assert len(suites) == 1
+        assert combined_suites.tests == 4
+        assert combined_suites.failures == 1
+        assert combined_suites.skipped == 1
 
 
-class Test_JunitXml(unittest.TestCase):
+
+@pytest.fixture()
+def locale_fixture():
+    old_locale = locale.getlocale(locale.LC_NUMERIC)
+    yield
+    locale.setlocale(locale.LC_NUMERIC, old_locale)
+
+class Locale:
+    @pytest.mark.parametrize("loc", ["", "en_US.UTF-8", "de_DE.UTF-8"])
+    def test_fromstring_numbers_locale_insensitive(self, loc, locale_fixture):
+        "Case relies on that LC_ALL is set in the console."
+        locale.setlocale(locale.LC_NUMERIC, loc)
+        text = """<testsuites>
+        <testsuite errors="0" failures="0" hostname="hooch" name="pytest" skipped="0" tests="2" time="1000.125" timestamp="2020-02-05T10:52:33.843536">
+        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="1,000.025"/>
+        <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.1"/>
+        </testsuite>
+        </testsuites>"""
+        result = JUnitXml.fromstring(text)
+        suite = list(iter(result))[0]
+        assert suite.time == 1000.125
+        cases = list(iter(suite))
+        assert cases[0].time == 1000.025
+        assert cases[1].time == 0.1
+
+
+class Test_JunitXml:
     def test_fromstring(self):
         text = """<testsuites><testsuite name="suitename1">
         <testcase name="testname1">
@@ -99,37 +122,17 @@ class Test_JunitXml(unittest.TestCase):
         <testcase name="testname2">
         </testcase></testsuite></testsuites>"""
         result = JUnitXml.fromstring(text)
-        self.assertEqual(result.time, 0)
-        self.assertEqual(len(result), 2)
+        assert len(result) == 2
+        assert result.time == 0
 
     def test_fromstring_no_testsuites(self):
         text = """<testsuite name="suitename1">
         <testcase name="testname1">
         </testcase></testsuite>"""
         result = JUnitXml.fromstring(text)
-        self.assertEqual(result.time, 0)
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
+        assert result.time == 0
 
-    def test_fromstring_numbers_locale_insensitive(self):
-        "Case relies on that LC_ALL is set in the console."
-        for loc in ["", "en_US.UTF-8", "de_DE.UTF-8"]:
-            old_locale = locale.getlocale(locale.LC_NUMERIC)
-            try:
-                locale.setlocale(locale.LC_NUMERIC, loc)
-                text = """<testsuites>
-                <testsuite errors="0" failures="0" hostname="hooch" name="pytest" skipped="0" tests="2" time="1000.125" timestamp="2020-02-05T10:52:33.843536">
-                <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="1,000.025"/>
-                <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.1"/>
-                </testsuite>
-                </testsuites>"""
-                result = JUnitXml.fromstring(text)
-                suite = list(iter(result))[0]
-                self.assertEqual(suite.time, 1000.125, msg=loc)
-                cases = list(iter(suite))
-                self.assertEqual(cases[0].time, 1000.025, msg=loc)
-                self.assertEqual(cases[1].time, 0.1, msg=loc)
-            finally:
-                locale.setlocale(locale.LC_NUMERIC, old_locale)
 
     def test_fromstring_multiple_fails(self):
         text = """<testsuites>
@@ -144,15 +147,15 @@ class Test_JunitXml(unittest.TestCase):
         </testsuite>
         </testsuites>"""
         result = JUnitXml.fromstring(text)
-        self.assertIsInstance(result, JUnitXml)
-        self.assertEqual(result.errors, 1)
-        self.assertEqual(result.skipped, 1)
+        assert isinstance(result, JUnitXml)
+        assert result.errors == 1
+        assert result.skipped == 1
         suite = list(iter(result))[0]
         cases = list(iter(suite))
-        self.assertEqual(len(cases[0].result), 0)
-        self.assertEqual(len(cases[1].result), 2)
+        assert len(cases[0].result) == 0
+        assert len(cases[1].result) == 2
         text = cases[1].result[1].text
-        self.assertTrue("@pytest.fixture" in text)
+        assert "@pytest.fixture" in text
 
     def test_fromroot_testsuite(self):
         text = """
@@ -167,14 +170,14 @@ class Test_JunitXml(unittest.TestCase):
         </testsuite>"""
         root_elemt = etree.fromstring(text)
         result = JUnitXml.fromroot(root_elemt)
-        self.assertIsInstance(result, TestSuite)
-        self.assertEqual(result.errors, 1)
-        self.assertEqual(result.skipped, 1)
+        assert isinstance(result, TestSuite)
+        assert result.errors == 1
+        assert result.skipped == 1
         cases = list(iter(result))
-        self.assertEqual(len(cases[0].result), 0)
-        self.assertEqual(len(cases[1].result), 2)
+        assert len(cases[0].result) == 0
+        assert len(cases[1].result) == 2
         text = cases[1].result[1].text
-        self.assertTrue("@pytest.fixture" in text)
+        assert "@pytest.fixture" in text
 
     def test_fromroot_testsuites(self):
         text = """<testsuites>
@@ -190,20 +193,20 @@ class Test_JunitXml(unittest.TestCase):
         </testsuites>"""
         root_elemt = etree.fromstring(text)
         result = JUnitXml.fromroot(root_elemt)
-        self.assertEqual(result.errors, 1)
-        self.assertEqual(result.skipped, 1)
+        assert result.errors == 1
+        assert result.skipped == 1
         suite = list(iter(result))[0]
         cases = list(iter(suite))
-        self.assertEqual(len(cases[0].result), 0)
-        self.assertEqual(len(cases[1].result), 2)
+        assert len(cases[0].result) == 0
+        assert len(cases[1].result) == 2
         text = cases[1].result[1].text
-        self.assertTrue("@pytest.fixture" in text)
+        assert "@pytest.fixture" in text
 
     def test_fromstring_invalid(self):
         text = """<random name="suitename1"></random>"""
-        with self.assertRaises(Exception) as context:
+        with pytest.raises(Exception) as context:
             JUnitXml.fromstring(text)
-        self.assertTrue(isinstance(context.exception, JUnitXmlError))
+        assert isinstance(context.value, JUnitXmlError)
 
     def test_add_suite(self):
         suite1 = TestSuite("suite1")
@@ -211,7 +214,7 @@ class Test_JunitXml(unittest.TestCase):
         result = JUnitXml()
         result.add_testsuite(suite1)
         result.add_testsuite(suite2)
-        self.assertEqual(len(result), 2)
+        assert len(result) == 2
 
     def test_construct_xml(self):
         suite1 = TestSuite()
@@ -221,13 +224,13 @@ class Test_JunitXml(unittest.TestCase):
         suite1.add_testcase(case1)
         result = JUnitXml()
         result.add_testsuite(suite1)
-        self.assertEqual(result._elem.tag, "testsuites")
+        assert result._elem.tag == "testsuites"
         suite = result._elem.findall("testsuite")
-        self.assertEqual(len(suite), 1)
-        self.assertEqual(suite[0].attrib["name"], "suite1")
+        assert len(suite) == 1
+        assert suite[0].attrib["name"] == "suite1"
         case = suite[0].findall("testcase")
-        self.assertEqual(len(case), 1)
-        self.assertEqual(case[0].attrib["name"], "case1")
+        assert len(case) == 1
+        assert case[0].attrib["name"] == "case1"
 
     def test_add(self):
         result1 = JUnitXml()
@@ -237,7 +240,7 @@ class Test_JunitXml(unittest.TestCase):
         suite2 = TestSuite("suite2")
         result2.add_testsuite(suite2)
         result3 = result1 + result2
-        self.assertEqual(len(result3), 2)
+        assert len(result3) == 2
 
     def test_add_same_suite(self):
         result1 = JUnitXml()
@@ -247,7 +250,7 @@ class Test_JunitXml(unittest.TestCase):
         suite2 = TestSuite()
         result2.add_testsuite(suite2)
         result3 = result1 + result2
-        self.assertEqual(len(result3), 1)
+        assert len(result3) == 1
 
     def test_iadd(self):
         result1 = JUnitXml()
@@ -257,7 +260,7 @@ class Test_JunitXml(unittest.TestCase):
         suite2 = TestSuite("suite2")
         result2.add_testsuite(suite2)
         result1 += result2
-        self.assertEqual(len(result1), 2)
+        assert len(result1) == 2
 
     def test_iadd_same_suite(self):
         result1 = JUnitXml()
@@ -267,7 +270,7 @@ class Test_JunitXml(unittest.TestCase):
         suite2 = TestSuite()
         result2.add_testsuite(suite2)
         result1 += result2
-        self.assertEqual(len(result1), 1)
+        assert len(result1) == 1
 
     def test_add_two_same_suites(self):
         suite1 = TestSuite()
@@ -279,9 +282,9 @@ class Test_JunitXml(unittest.TestCase):
         suite3 = TestSuite()
         suite2.add_testsuite(suite3)
         result = suite1 + suite2
-        self.assertIsInstance(result, TestSuite)
-        self.assertEqual(len(list(iter(result))), 2)
-        self.assertEqual(len(list(iter(result.testsuites()))), 1)
+        assert isinstance(result, TestSuite)
+        assert len(list(iter(result))) == 2
+        assert len(list(iter(result.testsuites()))) == 1
 
     def test_iadd_two_same_suites(self):
         suite1 = TestSuite()
@@ -293,9 +296,9 @@ class Test_JunitXml(unittest.TestCase):
         suite3 = TestSuite()
         suite2.add_testsuite(suite3)
         suite1 += suite2
-        self.assertIsInstance(suite1, TestSuite)
-        self.assertEqual(len(list(iter(suite1))), 2)
-        self.assertEqual(len(list(iter(suite1.testsuites()))), 1)
+        assert isinstance(suite1, TestSuite)
+        assert len(list(iter(suite1))) == 2
+        assert len(list(iter(suite1.testsuites()))) == 1
 
     def test_add_two_different_suites(self):
         suite1 = TestSuite(name="suite1")
@@ -305,8 +308,8 @@ class Test_JunitXml(unittest.TestCase):
         case2 = TestCase(name="case2")
         suite2.add_testcase(case2)
         result = suite1 + suite2
-        self.assertIsInstance(result, JUnitXml)
-        self.assertEqual(len(list(iter(result))), 2)
+        assert isinstance(result, JUnitXml)
+        assert len(list(iter(result))) == 2
 
     def test_iadd_two_different_suites(self):
         suite1 = TestSuite(name="suite1")
@@ -316,8 +319,8 @@ class Test_JunitXml(unittest.TestCase):
         case2 = TestCase(name="case2")
         suite2.add_testcase(case2)
         suite1 += suite2
-        self.assertIsInstance(suite1, JUnitXml)
-        self.assertEqual(len(list(iter(suite1))), 2)
+        assert isinstance(suite1, JUnitXml)
+        assert len(list(iter(suite1))) == 2
 
     def test_xml_statistics(self):
         result1 = JUnitXml()
@@ -328,20 +331,20 @@ class Test_JunitXml(unittest.TestCase):
         result2.add_testsuite(suite2)
         result3 = result1 + result2
         result3.update_statistics()
-        self.assertEqual(result3.tests, 0)
+        assert result3.tests == 0
 
 
-class Test_TestSuite(unittest.TestCase):
+class Test_TestSuite:
     def test_fromstring(self):
         text = """<testsuite name="suitename" time="1.32">
         <testcase name="testname">
         <failure message="failure message" type="FailureType"/>
         </testcase></testsuite>"""
         suite = TestSuite.fromstring(text)
-        self.assertEqual(suite.time, 1.32)
+        assert suite.time == 1.32
         suite.update_statistics()
-        self.assertEqual(suite.name, "suitename")
-        self.assertEqual(suite.tests, 1)
+        assert suite.name == "suitename"
+        assert suite.tests == 1
 
     def test_props_fromstring(self):
         text = """<testsuite name="suitename">
@@ -349,14 +352,14 @@ class Test_TestSuite(unittest.TestCase):
         </testsuite>"""
         suite = TestSuite.fromstring(text)
         for prop in suite.properties():
-            self.assertEqual(prop.name, "name1")
-            self.assertEqual(prop.value, "value1")
+            assert prop.name == "name1"
+            assert prop.value == "value1"
 
     def test_quoted_attr(self):
         text = """<testsuite name="suitename with &quot;quotes&quot;">
         </testsuite>"""
         suite = TestSuite.fromstring(text)
-        self.assertEqual(suite.name, 'suitename with "quotes"')
+        assert suite.name == 'suitename with "quotes"'
 
     def test_combining_testsuite_should_keep_name(self):
         text1 = """<testsuite name="suitename1" tests="2" failures="1">
@@ -375,20 +378,18 @@ class Test_TestSuite(unittest.TestCase):
         combined_suites += test_suite1
         combined_suites += test_suite2
 
-        self.assertEqual(
-            [s.name for s in combined_suites], ["suitename1", "suitename2"]
-        )
+        assert [s.name for s in combined_suites] == ["suitename1", "suitename2"]
 
     def test_len(self):
         text = """<testsuite name="suitename"><testcase name="testname"/>
         <testcase name="testname2"/>
         </testsuite>"""
         suite = TestSuite.fromstring(text)
-        self.assertEqual(len(suite), 2)
+        assert len(suite) == 2
 
     def test_add_case(self):
         suite = TestSuite()
-        self.assertEqual(suite.tests, 0)
+        assert suite.tests == 0
         case1 = TestCase()
         case2 = TestCase()
         case2.result = [Failure()]
@@ -401,24 +402,24 @@ class Test_TestSuite(unittest.TestCase):
         suite.add_testcase(case3)
         suite.add_testcase(case4)
         suite.update_statistics()
-        self.assertEqual(suite.tests, 4)
-        self.assertEqual(suite.failures, 1)
-        self.assertEqual(suite.errors, 1)
-        self.assertEqual(suite.skipped, 1)
+        assert suite.tests == 4
+        assert suite.failures == 1
+        assert suite.errors == 1
+        assert suite.skipped == 1
 
     def test_case_count(self):
         suite = TestSuite()
         case1 = TestCase()
         suite.add_testcase(case1)
-        self.assertEqual(suite.tests, 1)
-        self.assertEqual(suite.failures, 0)
+        assert suite.tests == 1
+        assert suite.failures == 0
 
     def test_add_property(self):
         suite = TestSuite()
         suite.add_property("name1", "value1")
         res_prop = next(suite.properties())
-        self.assertEqual(res_prop.name, "name1")
-        self.assertEqual(res_prop.value, "value1")
+        assert res_prop.name == "name1"
+        assert res_prop.value == "value1"
 
     def test_remove_case(self):
         suite = TestSuite()
@@ -429,7 +430,7 @@ class Test_TestSuite(unittest.TestCase):
         suite.add_testcase(case1)
         suite.add_testcase(case2)
         suite.remove_testcase(case1)
-        self.assertEqual(len(suite), 1)
+        assert len(suite) == 1
 
     def test_remove_property(self):
         suite = TestSuite()
@@ -439,7 +440,7 @@ class Test_TestSuite(unittest.TestCase):
         for prop in suite.properties():
             if prop.name == "name2":
                 suite.remove_property(prop)
-        self.assertEqual(len(list(suite.properties())), 2)
+        assert len(list(suite.properties())) == 2
 
     def test_remove_property_from_none(self):
         suite = TestSuite()
@@ -450,7 +451,7 @@ class Test_TestSuite(unittest.TestCase):
         suite = TestSuite("parent")
         childsuite = TestSuite("child")
         suite.add_testsuite(childsuite)
-        self.assertEqual(len(list(suite.testsuites())), 1)
+        assert len(list(suite.testsuites())) == 1
 
     def test_case_time(self):
         suite = TestSuite()
@@ -459,31 +460,31 @@ class Test_TestSuite(unittest.TestCase):
         case1.time = 15
         suite.add_testcase(case1)
         suite.update_statistics()
-        self.assertEqual(suite.time, 15)
+        assert suite.time == 15
 
     def test_wrong_attr_type(self):
         suite = TestSuite()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             suite.time = "abc"
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             suite.tests = 10.5
 
     def test_suite_eq(self):
         suite = TestSuite()
         suite.add_property("name1", "value1")
         suite2 = deepcopy(suite)
-        self.assertEqual(suite, suite2)
+        assert suite == suite2
 
     def test_suite_ne(self):
         suite = TestSuite()
         suite.add_property("name1", "value1")
         suite2 = deepcopy(suite)
         suite2.add_property("name2", "value2")
-        self.assertNotEqual(suite, suite2)
+        assert suite != suite2
 
     def test_add_cases(self):
         suite = TestSuite()
-        self.assertEqual(suite.tests, 0)
+        assert suite.tests == 0
         case1 = TestCase()
         case2 = TestCase()
         case2.result = [Failure()]
@@ -493,13 +494,13 @@ class Test_TestSuite(unittest.TestCase):
         case4.result = [Skipped()]
         suite.add_testcases([case1, case2, case3, case4])
         suite.update_statistics()
-        self.assertEqual(suite.tests, 4)
-        self.assertEqual(suite.failures, 1)
-        self.assertEqual(suite.errors, 1)
-        self.assertEqual(suite.skipped, 1)
+        assert suite.tests == 4
+        assert suite.failures == 1
+        assert suite.errors == 1
+        assert suite.skipped == 1
 
 
-class Test_TestCase(unittest.TestCase):
+class Test_TestCase:
     def test_case_fromstring(self):
         text = """<testcase name="testname">
         <failure message="failure message" type="FailureType"/>
@@ -507,10 +508,10 @@ class Test_TestCase(unittest.TestCase):
         <system-err>System err</system-err>
         </testcase>"""
         case = TestCase.fromstring(text)
-        self.assertEqual(case.name, "testname")
-        self.assertIsInstance(case.result[0], Failure)
-        self.assertEqual(case.system_out, "System out")
-        self.assertEqual(case.system_err, "System err")
+        assert case.name == "testname"
+        assert isinstance(case.result[0], Failure)
+        assert case.system_out == "System out"
+        assert case.system_err == "System err"
 
     def test_xml_multi_results(self):
         text = """<testcase name="testname">
@@ -520,26 +521,26 @@ class Test_TestCase(unittest.TestCase):
         """
         case = TestCase.fromstring(text)
         # no assertion raised
-        self.assertEqual(case.name, "testname")
-        self.assertEqual(len(case.result), 2)
+        assert case.name == "testname"
+        assert len(case.result) == 2
 
     def test_multi_results(self):
-        case = TestCase("testname", "testclassname")
+        case = TestCase("testname")
         err = Error("err msg", "err_type")
         fail1 = Failure("fail msg 1", "fail_type")
         fail2 = Failure("fail msg 2", "fail_type")
         fail3 = Failure("fail msg 3", "fail_type")
         fail4 = Failure("fail msg 4", "fail_type")
         case.result += [err]
-        self.assertEqual(len(case.result), 1)
+        assert len(case.result) == 1
         case.result += [fail1]
-        self.assertEqual(len(case.result), 2)
+        assert len(case.result) == 2
         case.result += [fail2]
-        self.assertEqual(len(case.result), 3)
+        assert len(case.result) == 3
         case.result += [fail3]
-        self.assertEqual(len(case.result), 4)
+        assert len(case.result) == 4
         case.result += [fail4]
-        self.assertEqual(len(case.result), 5)
+        assert len(case.result) == 5
 
     def test_case_attributes(self):
         case = TestCase()
@@ -548,61 +549,61 @@ class Test_TestCase(unittest.TestCase):
         case.time = 15.123
         case.result = [Skipped()]
         case.result[0].text = "woah skipped"
-        self.assertEqual(case.name, "testname")
-        self.assertEqual(case.classname, "testclassname")
-        self.assertEqual(case.time, 15.123)
-        self.assertIsInstance(case.result[0], Skipped)
-        self.assertEqual(case.result[0].text, "woah skipped")
+        assert case.name == "testname"
+        assert case.classname == "testclassname"
+        assert case.time == 15.123
+        assert isinstance(case.result[0], Skipped)
+        assert case.result[0].text == "woah skipped"
 
     def test_case_init_with_attributes(self):
         case = TestCase("testname", "testclassname", 15.123)
         case.result = [Skipped()]
-        self.assertEqual(case.name, "testname")
-        self.assertEqual(case.classname, "testclassname")
-        self.assertEqual(case.time, 15.123)
-        self.assertIsInstance(case.result[0], Skipped)
+        assert case.name == "testname"
+        assert case.classname == "testclassname"
+        assert case.time == 15.123
+        assert isinstance(case.result[0], Skipped)
 
     def test_case_output(self):
         case = TestCase()
         case.system_err = "error message"
         case.system_out = "out message"
-        self.assertEqual(case.system_err, "error message")
-        self.assertEqual(case.system_out, "out message")
+        assert case.system_err == "error message"
+        assert case.system_out == "out message"
         case.system_err = "error2"
         case.system_out = "out2"
-        self.assertEqual(case.system_err, "error2")
-        self.assertEqual(case.system_out, "out2")
+        assert case.system_err == "error2"
+        assert case.system_out == "out2"
 
     def test_update_results(self):
         case = TestCase()
         case.result = [Skipped()]
         case.result = [Failure(), Skipped()]
-        self.assertEqual(len(case.result), 2)
+        assert len(case.result) == 2
 
     def test_monkypatch(self):
         TestCase.id = Attr("id")
         case = TestCase()
         case.id = "100"
-        self.assertEqual(case.id, "100")
+        assert case.id == "100"
 
     def test_equal(self):
         case = TestCase()
         case.name = "test1"
         case2 = TestCase()
         case2.name = "test1"
-        self.assertEqual(case, case2)
+        assert case == case2
 
     def test_not_equal(self):
         case = TestCase()
         case.name = "test1"
         case2 = TestCase()
         case2.name = "test2"
-        self.assertNotEqual(case, case2)
+        assert case != case2
 
     def test_from_elem(self):
         elem = etree.Element("testcase", name="case1")
         case = TestCase.fromelem(elem)
-        self.assertEqual(case.name, "case1")
+        assert case.name == "case1"
 
     def test_from_junit_elem(self):
         case = TestCase()
@@ -613,53 +614,50 @@ class Test_TestCase(unittest.TestCase):
             assertions = Attr()
 
         other_case = TestOtherCase.fromelem(case)
-
-        self.assertEqual(case.name, other_case.name)
-        self.assertRaises(AttributeError, lambda: case.assertions)
+        assert case.name == other_case.name
+        assert other_case.assertions is None
+        pytest.raises(AttributeError, lambda: case.assertions)
         other_case.assertions = 20
-        self.assertEqual(other_case.assertions, "20")
+        assert other_case.assertions == "20"
 
     def test_to_string(self):
         case = TestCase()
         case.name = "test1"
         case_str = case.tostring()
-        self.assertIn(b"test1", case_str)
+        assert b"test1" in case_str
 
     def test_to_nonascii_string(self):
         case = TestCase()
         case.name = "测试1"
         case.result = [Failure("失败", "类型")]
         case_str = case.tostring()
-        self.assertIn("测试1", case_str.decode("utf-8"))
-        self.assertIn("失败", case_str.decode("utf-8"))
-        self.assertIn("类型", case_str.decode("utf-8"))
+        assert "测试1" in case_str.decode("utf-8")
+        assert "失败" in case_str.decode("utf-8")
+        assert "类型" in case_str.decode("utf-8")
 
     def test_system_out(self):
         case = TestCase()
         case.name = "case1"
-        self.assertIsNone(case.system_out)
+        assert case.system_out is None
         case.system_out = "output"
-        self.assertEqual(case.system_out, "output")
+        assert case.system_out == "output"
 
     def test_system_err(self):
         case = TestCase()
         case.name = "case1"
-        self.assertIsNone(case.system_err)
+        assert case.system_err is None
         case.system_err = "error"
-        self.assertEqual(case.system_err, "error")
+        assert case.system_err == "error"
 
     def test_result_eq(self):
-        # TODO: Weird, need to think of a better API
-        self.assertEqual(Failure("A"), Failure("A"))
-        self.assertNotEqual(Skipped("B"), Skipped("A"))
-        self.assertNotEqual(Error("C"), Error("B"))
+        assert Failure("A") == Failure("A")
+        assert Skipped("B") != Skipped("A")
+        assert Error("C") != Error("B")
 
     def test_result_attrs(self):
         res1 = Failure("A")
         # NOTE: lxml gives spaceless result
-        self.assertIn(
-            res1.tostring(), [b'<failure message="A" />', b'<failure message="A"/>']
-        )
+        assert res1.tostring() in [b'<failure message="A" />', b'<failure message="A"/>']
 
     def test_add_child_element(self):
         class CustomElement(Element):
@@ -671,50 +669,45 @@ class Test_TestCase(unittest.TestCase):
         custom = CustomElement()
         testcase.append(custom)
 
-        self.assertIn(
-            testcase.tostring(),
-            [b"<testcase><custom /></testcase>", b"<testcase><custom/></testcase>"],
-        )
+        assert testcase.tostring() in [b"<testcase><custom /></testcase>", b"<testcase><custom/></testcase>"]
 
     def test_case_is_skipped(self):
         case = TestCase()
         case.result = [Skipped()]
-        self.assertTrue(case.is_skipped)
-        self.assertFalse(case.is_passed)
+        assert case.is_skipped
+        assert not case.is_passed
 
     def test_case_is_passed(self):
         case = TestCase()
         case.result = []
-        self.assertFalse(case.is_skipped)
-        self.assertTrue(case.is_passed)
+        assert not case.is_skipped
+        assert case.is_passed
 
     def test_case_is_failed(self):
         case = TestCase()
         case.result = [Failure()]
-        self.assertFalse(case.is_skipped)
-        self.assertFalse(case.is_passed)
+        assert not case.is_skipped
+        assert not case.is_passed
 
-
-class Test_Properties(unittest.TestCase):
+class Test_Properties:
     def test_property_repr1(self):
         prop1 = Property("prop1", "1")
-        self.assertEqual(
-            prop1.__repr__(), '<Element \'property\' name="prop1" value="1">'
-        )
+        assert prop1.__repr__() == '<Element \'property\' name="prop1" value="1">'
+
 
     def test_property_repr2(self):
         prop1 = TestSuite()
-        self.assertEqual(prop1.__repr__(), "<Element 'testsuite'>")
+        assert prop1.__repr__() == "<Element 'testsuite'>"
 
     def test_property_eq(self):
         prop1 = Property("prop1", "1")
         prop2 = Property("prop1", "1")
-        self.assertEqual(prop1, prop2)
+        assert prop1 == prop2
 
     def test_property_ne(self):
         prop1 = Property("prop1", "1")
         prop2 = Property("prop1", "2")
-        self.assertNotEqual(prop1, prop2)
+        assert prop1 != prop2
 
     def test_properties_eq(self):
         prop1 = Property("prop1", "1")
@@ -728,7 +721,7 @@ class Test_Properties(unittest.TestCase):
         props2 = Properties()
         props2.add_property(prop3)
         props2.add_property(prop4)
-        self.assertEqual(props1, props2)
+        assert props1 == props2
 
     def test_properties_ne(self):
         prop1 = Property("prop1", "1")
@@ -741,7 +734,7 @@ class Test_Properties(unittest.TestCase):
         props2 = Properties()
         props2.add_property(prop3)
         props2.add_property(prop4)
-        self.assertNotEqual(props1, props2)
+        assert props1 != props2
 
     def test_properties_ne2(self):
         prop1 = Property("prop1", "1")
@@ -752,10 +745,10 @@ class Test_Properties(unittest.TestCase):
         props1.add_property(prop2)
         props2 = Properties()
         props2.add_property(prop3)
-        self.assertNotEqual(props1, props2)
+        assert props1 != props2
 
 
-class Test_Attrs(unittest.TestCase):
+class Test_Attrs:
     def test_attr(self):
         TestCase.text = Attr("text")
         TestCase.int = IntAttr("int")
@@ -764,6 +757,6 @@ class Test_Attrs(unittest.TestCase):
         element.text = "foo"
         element.int = 10
         element.float = 8.5
-        self.assertEqual(element.text, "foo")
-        self.assertEqual(element.int, 10)
-        self.assertEqual(element.float, 8.5)
+        assert element.text == "foo"
+        assert element.int == 10
+        assert element.float == 8.5

--- a/tests/test_xunit2.py
+++ b/tests/test_xunit2.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 from junitparser.xunit2 import JUnitXml, TestSuite, TestCase, RerunFailure
 from junitparser import Failure
 from copy import deepcopy
 
 
-class Test_TestCase(unittest.TestCase):
+class Test_TestCase:
     def test_case_fromstring(self):
         text = """<testcase name="testname">
         <failure message="failure message" type="FailureType"/>
@@ -21,83 +20,86 @@ class Test_TestCase(unittest.TestCase):
         <system-err>System err</system-err>
         </testcase>"""
         case = TestCase.fromstring(text)
-        self.assertEqual(case.name, "testname")
-        self.assertIsInstance(case.result[0], Failure)
-        self.assertEqual(case.system_out, "System out")
-        self.assertEqual(case.system_err, "System err")
+        assert case.name == "testname"
+        assert isinstance(case.result[0], Failure)
+        assert case.system_out == "System out"
+        assert case.system_err == "System err"
         rerun_failures = case.rerun_failures()
-        self.assertEqual(len(rerun_failures), 2)
-        self.assertEqual(rerun_failures[0].message, "Not found")
-        self.assertEqual(rerun_failures[0].stack_trace, None)
-        self.assertEqual(rerun_failures[0].system_out, "No ha encontrado")
-        self.assertEqual(rerun_failures[1].stack_trace, "Stacktrace")
-        self.assertEqual(rerun_failures[1].system_err, "Error del servidor")
-        self.assertEqual(len(case.rerun_errors()), 0)
-        self.assertEqual(len(case.flaky_failures()), 0)
-        self.assertEqual(len(case.flaky_errors()), 0)
+        assert len(rerun_failures) == 2
+        assert rerun_failures[0].message == "Not found"
+        assert rerun_failures[0].stack_trace is None
+        assert rerun_failures[0].system_out == "No ha encontrado"
+        assert rerun_failures[0].system_err is None
+        assert rerun_failures[1].message == "Server error"
+        assert rerun_failures[1].stack_trace == "Stacktrace"
+        assert rerun_failures[1].system_out is None
+        assert rerun_failures[1].system_err == "Error del servidor"
+        assert len(case.rerun_errors()) == 0
+        assert len(case.flaky_failures()) == 0
+        assert len(case.flaky_errors()) == 0
 
-    def test_rerun(self):
+    def test_case_rerun(self):
         case = TestCase("testname")
         rerun_failure = RerunFailure("Not found", "404")
-        self.assertEqual(rerun_failure.system_out, None)
-        self.assertEqual(rerun_failure.system_err, None)
+        assert rerun_failure.system_out == None
+        assert rerun_failure.system_err == None
         rerun_failure.stack_trace = "Stack"
         rerun_failure.system_err = "E404"
         rerun_failure.system_out = "NOT FOUND"
         case.add_rerun_result(rerun_failure)
-        self.assertEqual(len(case.rerun_failures()), 1)
+        assert len(case.rerun_failures()) == 1
         # Interesting, same object is only added once by xml libs
         failure2 = deepcopy(rerun_failure)
         failure2.stack_trace = "Stack2"
         failure2.system_err = "E401"
         failure2.system_out = "401 Error"
         case.add_rerun_result(failure2)
-        self.assertEqual(len(case.rerun_failures()), 2)
+        assert len(case.rerun_failures()) == 2
 
 
-class Test_TestSuite(unittest.TestCase):
+class Test_TestSuite:
     def test_properties(self):
         suite = TestSuite("mySuite")
-        self.assertEqual(suite.system_out, None)
-        self.assertEqual(suite.system_err, None)
+        assert suite.system_out is None
+        assert suite.system_err is None
         suite.system_err = "System err"
         suite.system_out = "System out"
-        self.assertEqual(suite.system_out, "System out")
-        self.assertEqual(suite.system_err, "System err")
+        assert suite.system_out == "System out"
+        assert suite.system_err == "System err"
         suite.system_err = "System err2"
         suite.system_out = "System out2"
-        self.assertEqual(suite.system_out, "System out2")
-        self.assertEqual(suite.system_err, "System err2")
+        assert suite.system_out == "System out2"
+        assert suite.system_err == "System err2"
+
 
     def test_iterate_case(self):
         suite = TestSuite("mySuite")
         suite.add_testcase(TestCase("test1"))
         case = next(iter(suite))
-        self.assertEqual(case.name, "test1")
+        assert case.name == "test1"
 
     def test_iterate_suite(self):
         suite = TestSuite("mySuite")
         suite.add_testsuite(TestSuite("suite1"))
         suite = next(suite.testsuites())
-        self.assertEqual(suite.name, "suite1")
+        assert suite.name == "suite1"
 
     def test_remove_case(self):
         suite = TestSuite("mySuite")
         test = TestCase("test1")
         suite.add_testcase(test)
         suite.remove_testcase(test)
-        self.assertEqual(list(iter(suite)), [])
+        assert len(suite) == 0
 
 
-class Test_JUnitXml(unittest.TestCase):
+class Test_JUnitXml:
     def test_init(self):
         xml = JUnitXml("tests")
-        self.assertEqual(xml.name, "tests")
+        assert xml.name == "tests"
         xml = JUnitXml("myname")
         xml.add_testsuite(TestSuite("suite1"))
         xml.update_statistics()
-        self.assertEqual(xml.skipped, None)
-        # errors="0"
-        self.assertEqual(xml.tostring().count(b"errors"), 2)
-        # "skipped" attribute doesn't exist
-        self.assertEqual(xml.tostring().count(b"skipped"), 1)
+        assert xml.skipped is None
+        assert xml.tostring().count(b"errors") == 2
+        assert xml.tostring().count(b"skipped") == 1
+

--- a/tests/test_xunit2.py
+++ b/tests/test_xunit2.py
@@ -71,7 +71,6 @@ class Test_TestSuite:
         assert suite.system_out == "System out2"
         assert suite.system_err == "System err2"
 
-
     def test_iterate_case(self):
         suite = TestSuite("mySuite")
         suite.add_testcase(TestCase("test1"))
@@ -102,4 +101,3 @@ class Test_JUnitXml:
         assert xml.skipped is None
         assert xml.tostring().count(b"errors") == 2
         assert xml.tostring().count(b"skipped") == 1
-


### PR DESCRIPTION
The command line conversion tools didn't work, but Copilot works quite good for converting individual cases. Probably the only good case to justify me buying it. Still a lot of manual copy/paste though.

Some cases are rewritten to use `parametrize`.