### PR TITLE
Remove unused `future` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="Weiwei Wang",
     author_email="gastlygem@gmail.com",
     license="Apache 2.0",
-    install_requires=["future"],
+    install_requires=[],
     keywords="junit xunit xml parser",
     packages=find_packages(exclude=["tests"]),
     entry_points={"console_scripts": ["junitparser=junitparser.cli:main"]},


### PR DESCRIPTION
This dependency was removed from the `requirements.txt` for the 3.1.0 release, but it appears it was missed from removal here.

This removes the now unused dependency, as this dependency has install problems in a few situations.