### PR TITLE
Add files now needed for the ReadTheDocs run

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# ReadTheDocs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# Python dependencies to build the documentation
+
+Sphinx ~= 7.0


### PR DESCRIPTION
See https://docs.readthedocs.io/en/stable/config-file/v2.html

Without this, the builds are failing, see e.g. https://readthedocs.org/projects/junitparser/builds/21963453/