### PR TITLE
Exclude TestCase and TestSuite from pytest discovery

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -314,6 +314,7 @@ class TestCase(Element):
     name = Attr()
     classname = Attr()
     time = FloatAttr()
+    __test__ = False
 
     def __init__(self, name: str = None, classname: str = None, time: float = None):
         super().__init__(self._tag)
@@ -489,6 +490,7 @@ class TestSuite(Element):
     failures = IntAttr()
     errors = IntAttr()
     skipped = IntAttr()
+    __test__ = False
 
     def __init__(self, name=None):
         super().__init__(self._tag)


### PR DESCRIPTION
`pytest` gives a warning on `TestCase` and `TestSuite` during test discovery. 
Adding `__test__ = False` to each class excludes from test discovery and removes warning.