### PR TITLE
some more type annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.9", "3.10", "3.11", "3.x"]
+        python-version: ["3.6", "3.x"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.x"]
+        python-version: ["3.6", "3.9", "3.10", "3.11", "3.x"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.x"]
+        python-version: ["3.6", "3.7", "3.8", "3.x"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -11,6 +11,7 @@ See the documentation for other supported schemas.
 
 import itertools
 from copy import deepcopy
+from typing import List, Self
 
 try:
     from lxml import etree
@@ -504,7 +505,7 @@ class TestSuite(Element):
     def __len__(self):
         return len(list(self.__iter__()))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Self):
         def props_eq(props1, props2):
             props1 = list(props1)
             props2 = list(props2)
@@ -521,7 +522,7 @@ class TestSuite(Element):
             and self.timestamp == other.timestamp
         ) and props_eq(self.properties(), other.properties())
 
-    def __add__(self, other):
+    def __add__(self, other: Self):
         if self == other:
             # Merge the two testsuites
             result = deepcopy(self)
@@ -537,7 +538,7 @@ class TestSuite(Element):
             result.add_testsuite(other)
         return result
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: Self):
         if self == other:
             for case in other:
                 self._add_testcase_no_update_stats(case)
@@ -552,7 +553,7 @@ class TestSuite(Element):
         result.add_testsuite(other)
         return result
 
-    def remove_testcase(self, testcase):
+    def remove_testcase(self, testcase: TestCase):
         """Remove testcase *testcase* from the testsuite."""
         for case in self:
             if case == testcase:
@@ -580,7 +581,7 @@ class TestSuite(Element):
         self.skipped = skipped
         self.time = round(time, 3)
 
-    def add_property(self, name, value):
+    def add_property(self, name: str, value: str):
         """Add a property *name* = *value* to the testsuite.
 
         See :class:`Property` and :class:`Properties`.
@@ -593,24 +594,24 @@ class TestSuite(Element):
         prop = Property(name, value)
         props.add_property(prop)
 
-    def add_testcase(self, testcase):
+    def add_testcase(self, testcase: TestCase):
         """Add a testcase *testcase* to the testsuite."""
         self.append(testcase)
         self.update_statistics()
 
-    def add_testcases(self, testcases):
+    def add_testcases(self, testcases: List[TestCase]):
         """Add testcases *testcases* to the testsuite."""
         self.extend(testcases)
         self.update_statistics()
 
-    def _add_testcase_no_update_stats(self, testcase):
+    def _add_testcase_no_update_stats(self, testcase: TestCase):
         """Add *testcase* to the testsuite (without updating statistics).
 
         For internal use only to avoid quadratic behaviour in merge.
         """
         self.append(testcase)
 
-    def add_testsuite(self, suite):
+    def add_testsuite(self, suite: Self):
         """Add a testsuite *suite* to the testsuite."""
         self.append(suite)
 

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -11,7 +11,7 @@ See the documentation for other supported schemas.
 
 import itertools
 from copy import deepcopy
-from typing import List, Self
+from typing import List
 
 try:
     from lxml import etree
@@ -505,7 +505,7 @@ class TestSuite(Element):
     def __len__(self):
         return len(list(self.__iter__()))
 
-    def __eq__(self, other: Self):
+    def __eq__(self, other):
         def props_eq(props1, props2):
             props1 = list(props1)
             props2 = list(props2)
@@ -522,7 +522,7 @@ class TestSuite(Element):
             and self.timestamp == other.timestamp
         ) and props_eq(self.properties(), other.properties())
 
-    def __add__(self, other: Self):
+    def __add__(self, other):
         if self == other:
             # Merge the two testsuites
             result = deepcopy(self)
@@ -538,7 +538,7 @@ class TestSuite(Element):
             result.add_testsuite(other)
         return result
 
-    def __iadd__(self, other: Self):
+    def __iadd__(self, other):
         if self == other:
             for case in other:
                 self._add_testcase_no_update_stats(case)
@@ -611,7 +611,7 @@ class TestSuite(Element):
         """
         self.append(testcase)
 
-    def add_testsuite(self, suite: Self):
+    def add_testsuite(self, suite):
         """Add a testsuite *suite* to the testsuite."""
         self.append(suite)
 


### PR DESCRIPTION
Some more type annotations.

Note to self: the `Self` type is only supported with python 3.11, and the official backport only works for 3.8+, while this package still has quite a few users on Python 3.6 and 3.7, so it is not added.