### PR TITLE
Fix huge_tree for lxml

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -747,7 +747,8 @@ class JUnitXml(Element):
         if parse_func:
             tree = parse_func(filepath)
         else:
-            tree = etree.parse(filepath)  # nosec
+            parser = etree.XMLParser(encoding='utf-8', recover=True)
+            tree = etree.parse(filepath, parser)  # nosec
         root_elem = tree.getroot()
         instance = cls.fromroot(root_elem)
         instance.filepath = filepath


### PR DESCRIPTION
Fix exception when paring large xml files

```
lxml.etree.XMLSyntaxError: xmlSAX2Characters: huge text node, line 110745, column 34
```