### PR TITLE
Calling `junitparser.xunit2.JUnitXml.fromroot` should produce `junitparser.xunit2.TestSuite`

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -665,6 +665,8 @@ class JUnitXml(Element):
     errors = IntAttr()
     skipped = IntAttr()
 
+    testsuite = TestSuite
+
     def __init__(self, name=None):
         super().__init__(self._tag)
         self.filepath = None
@@ -729,7 +731,7 @@ class JUnitXml(Element):
         if root_elem.tag == "testsuites":
             instance = cls()
         elif root_elem.tag == "testsuite":
-            instance = TestSuite()
+            instance = cls.testsuite()
         else:
             raise JUnitXmlError("Invalid format.")
         instance._elem = root_elem

--- a/junitparser/xunit2.py
+++ b/junitparser/xunit2.py
@@ -19,26 +19,6 @@ from . import junitparser
 T = TypeVar("T")
 
 
-class JUnitXml(junitparser.JUnitXml):
-    # Pytest and xunit schema doesn't have "skipped" in testsuites
-    skipped = None
-
-    def update_statistics(self):
-        """Update test count, time, etc."""
-        time = 0
-        tests = failures = errors = 0
-        for suite in self:
-            suite.update_statistics()
-            tests += suite.tests
-            failures += suite.failures
-            errors += suite.errors
-            time += suite.time
-        self.tests = tests
-        self.failures = failures
-        self.errors = errors
-        self.time = round(time, 3)
-
-
 class TestSuite(junitparser.TestSuite):
     """TestSuite for Pytest, with some different attributes."""
 
@@ -91,6 +71,28 @@ class TestSuite(junitparser.TestSuite):
         else:
             err = junitparser.SystemErr(value)
             self.append(err)
+
+
+class JUnitXml(junitparser.JUnitXml):
+    # Pytest and xunit schema doesn't have "skipped" in testsuites
+    skipped = None
+
+    testsuite = TestSuite
+
+    def update_statistics(self):
+        """Update test count, time, etc."""
+        time = 0
+        tests = failures = errors = 0
+        for suite in self:
+            suite.update_statistics()
+            tests += suite.tests
+            failures += suite.failures
+            errors += suite.errors
+            time += suite.time
+        self.tests = tests
+        self.failures = failures
+        self.errors = errors
+        self.time = round(time, 3)
 
 
 class StackTrace(junitparser.System):

--- a/tests/test_xunit2.py
+++ b/tests/test_xunit2.py
@@ -101,3 +101,14 @@ class Test_JUnitXml:
         assert xml.skipped is None
         assert xml.tostring().count(b"errors") == 2
         assert xml.tostring().count(b"skipped") == 1
+
+    def test_fromstring(self):
+        text = """<testsuite name="suite name">
+         <testcase name="test name 1"/>
+         <testcase name="test name 2"/>
+        </testsuite>"""
+        suite = JUnitXml.fromstring(text)
+        assert isinstance(suite, TestSuite)
+        assert suite.name == "suite name"
+        assert len(list(suite)) == 2
+        assert [test.name for test in suite] == ["test name 1", "test name 2"]


### PR DESCRIPTION
Currently, `junitparser.xunit2.JUnitXml.fromroot` returns a `junitparser.JUnitXml.TestSuite`, but you would expect a `junitparser.xunit2.TestSuite`, which implements XUnit2-specific features.