### PR TITLE
Add properties to TestCase for the two other result-types

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -347,36 +347,22 @@ class TestCase(Element):
     @property
     def is_failure(self):
         """Whether this testcase failed."""
-        for r in self.result:
-            if isinstance(r, Failure):
-                return True
-        return False
+        return any(isinstance(r, Failure) for r in self.result)
 
     @property
     def is_error(self):
         """Whether this testcase errored."""
-        for r in self.result:
-            if isinstance(r, Error):
-                return True
-        return False
+        return any(isinstance(r, Error) for r in self.result)
 
     @property
     def is_skipped(self):
         """Whether this testcase was skipped."""
-        for r in self.result:
-            if isinstance(r, Skipped):
-                return True
-        return False
+        return any(isinstance(r, Skipped) for r in self.result)
 
     @property
     def result(self):
         """A list of :class:`Failure`, :class:`Skipped`, or :class:`Error` objects."""
-        results = []
-        for entry in self:
-            if isinstance(entry, tuple(POSSIBLE_RESULTS)):
-                results.append(entry)
-
-        return results
+        return [r for r in self if isinstance(r, tuple(POSSIBLE_RESULTS))]
 
     @result.setter
     def result(self, value: Union[Result, List[Result]]):

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -368,13 +368,13 @@ class TestCase(Element):
     def result(self, value: Union[Result, List[Result]]):
         # First remove all existing results
         for entry in self.result:
-            if any(isinstance(entry, r) for r in POSSIBLE_RESULTS):
+            if isinstance(entry, tuple(POSSIBLE_RESULTS)):
                 self.remove(entry)
         if isinstance(value, Result):
             self.append(value)
         elif isinstance(value, list):
             for entry in value:
-                if any(isinstance(entry, r) for r in POSSIBLE_RESULTS):
+                if isinstance(entry, tuple(POSSIBLE_RESULTS)):
                     self.append(entry)
 
     @property

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -365,22 +365,25 @@ class TestCase(Element):
         return any(isinstance(r, Skipped) for r in self.result)
 
     @property
-    def result(self) -> list[FinalResult]:
+    def result(self) -> List[FinalResult]:
         """A list of :class:`Failure`, :class:`Skipped`, or :class:`Error` objects."""
         return [r for r in self if isinstance(r, FinalResult)]
 
     @result.setter
-    def result(self, value: Union[Result, List[Result]]):
+    def result(self, value: Union[FinalResult, List[FinalResult]]):
+        # Check typing
+        if not (isinstance(value, FinalResult) or
+                isinstance(value, list) and all(isinstance(item, FinalResult) for item in value)):
+            raise ValueError("Value must be either FinalResult or list of FinalResult")
+
         # First remove all existing results
         for entry in self.result:
-            if isinstance(entry, FinalResult):
-                self.remove(entry)
-        if isinstance(value, Result):
+            self.remove(entry)
+        if isinstance(value, FinalResult):
             self.append(value)
-        elif isinstance(value, list):
+        else:
             for entry in value:
-                if isinstance(entry, FinalResult):
-                    self.append(entry)
+                self.append(entry)
 
     @property
     def system_out(self):

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -345,6 +345,22 @@ class TestCase(Element):
         return not self.result
 
     @property
+    def is_failure(self):
+        """Whether this testcase failed."""
+        for r in self.result:
+            if isinstance(r, Failure):
+                return True
+        return False
+
+    @property
+    def is_error(self):
+        """Whether this testcase errored."""
+        for r in self.result:
+            if isinstance(r, Error):
+                return True
+        return False
+
+    @property
     def is_skipped(self):
         """Whether this testcase was skipped."""
         for r in self.result:

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -273,9 +273,6 @@ class Error(FinalResult):
         return super().__eq__(other)
 
 
-FINAL_RESULTS = {Failure, Error, Skipped}
-
-
 class System(Element):
     """Parent class for :class:`SystemOut` and :class:`SystemErr`.
 
@@ -334,7 +331,7 @@ class TestCase(Element):
         return super().__hash__()
 
     def __iter__(self):
-        all_types = set.union(FINAL_RESULTS, {SystemOut}, {SystemErr})
+        all_types = {Failure, Error, Skipped, SystemOut, SystemErr}
         for elem in self._elem.iter():
             for entry_type in all_types:
                 if elem.tag == entry_type._tag:

--- a/junitparser/xunit2.py
+++ b/junitparser/xunit2.py
@@ -99,8 +99,10 @@ class StackTrace(junitparser.System):
     _tag = "stackTrace"
 
 
-class RerunType(junitparser.Result):
-    _tag = "rerunType"
+class RerunResult(junitparser.Result):
+    """Base class for intermediate / rerun test result (in contrast to JUnit FinalResult)."""
+
+    _tag = None
 
     @property
     def stack_trace(self):
@@ -157,19 +159,19 @@ class RerunType(junitparser.Result):
             self.append(err)
 
 
-class RerunFailure(RerunType):
+class RerunFailure(RerunResult):
     _tag = "rerunFailure"
 
 
-class RerunError(RerunType):
+class RerunError(RerunResult):
     _tag = "rerunError"
 
 
-class FlakyFailure(RerunType):
+class FlakyFailure(RerunResult):
     _tag = "flakyFailure"
 
 
-class FlakyError(RerunType):
+class FlakyError(RerunResult):
     _tag = "flakyError"
 
 
@@ -199,6 +201,6 @@ class TestCase(junitparser.TestCase):
         """<flakyError>"""
         return self._rerun_results(FlakyError)
 
-    def add_rerun_result(self, result: RerunType):
+    def add_rerun_result(self, result: RerunResult):
         """Append a rerun result to the testcase. A testcase can have multiple rerun results."""
         self.append(result)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -685,18 +685,32 @@ class Test_TestCase:
         case.result = [Skipped()]
         assert case.is_skipped
         assert not case.is_passed
+        assert not case.is_failure
+        assert not case.is_error
 
     def test_case_is_passed(self):
         case = TestCase()
         case.result = []
         assert not case.is_skipped
         assert case.is_passed
+        assert not case.is_failure
+        assert not case.is_error
 
     def test_case_is_failed(self):
         case = TestCase()
         case.result = [Failure()]
         assert not case.is_skipped
         assert not case.is_passed
+        assert case.is_failure
+        assert not case.is_error
+
+    def test_case_is_error(self):
+        case = TestCase()
+        case.result = [Error()]
+        assert not case.is_skipped
+        assert not case.is_passed
+        assert not case.is_failure
+        assert case.is_error
 
 
 class Test_Properties:


### PR DESCRIPTION
This PR adds the two missing properties `is_failure` and `is_error` to the `TestCase` class. They are implemented identically to the existing `is_skipped` property.

We are using `junitparser` to fill a table with all testcases and it feels really inconsistent to have three different ways to check for success (directly from propriety), failure (checking two other proprieties are unset) and errors (`isinstance` check on results). So this Pr would make it much easier and consistent.


-----
created in cooperation with @jonahRo