### PR TITLE
Type-hinting for looping over the xml children

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -10,7 +10,7 @@ See the documentation for other supported schemas.
 """
 import itertools
 from copy import deepcopy
-from typing import List, Union
+from typing import List, Union, Iterator
 
 try:
     from lxml import etree
@@ -328,7 +328,7 @@ class TestCase(Element):
     def __hash__(self):
         return super().__hash__()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Union[Result, System]]:
         all_types = set.union(POSSIBLE_RESULTS, {SystemOut}, {SystemErr})
         for elem in self._elem.iter():
             for entry_type in all_types:
@@ -454,7 +454,7 @@ class Properties(Element):
     def add_property(self, property_: Property):
         self.append(property_)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Property]:
         return super().iterchildren(Property)
 
     def __eq__(self, other):
@@ -500,7 +500,7 @@ class TestSuite(Element):
         self.name = name
         self.filepath = None
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[TestCase]:
         return itertools.chain(
             super().iterchildren(TestCase),
             (case for suite in super().iterchildren(TestSuite) for case in suite),
@@ -674,7 +674,7 @@ class JUnitXml(Element):
         self.filepath = None
         self.name = name
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[TestSuite]:
         return super().iterchildren(TestSuite)
 
     def __len__(self):

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -748,7 +748,7 @@ class JUnitXml(Element):
     @classmethod
     def fromfile(cls, filepath: str, parse_func=None):
         """Initiate the object from a report file."""
-        if parse_func:
+        if parse_func is not None:
             tree = parse_func(filepath)
         else:
             tree = etree.parse(filepath)  # nosec

--- a/junitparser/xunit2.py
+++ b/junitparser/xunit2.py
@@ -13,7 +13,7 @@ There may be many others that I'm not aware of.
 """
 
 import itertools
-from typing import List, TypeVar
+from typing import List, TypeVar, Iterator
 from . import junitparser
 
 T = TypeVar("T")
@@ -30,7 +30,7 @@ class TestSuite(junitparser.TestSuite):
     url = junitparser.Attr()
     version = junitparser.Attr()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator["TestCase"]:
         return itertools.chain(
             super().iterchildren(TestCase),
             (case for suite in super().iterchildren(TestSuite) for case in suite),


### PR DESCRIPTION
Previously `for suite in xml` and `for case in suite` would not detect the proper types for `suite` and `case` and not give intelisense.

this fixes the elements being detected as type `Any` and instead the proper type is detected, enableing auto-completeion.