### PR TITLE
Write to file and file-like objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [4.0.0]
+### Breaking
+- Renamed argument `filepath` of methods `write_xml`, `TestSuite.write`, and `JUnitXml.write`
+  to `file_or_filename`, as these methods now support file objects and file-like objects.
+- Turned positional argument `pretty` of methods `write_xml`, `TestSuite.write`, and `JUnitXml.write` into keyword argument.
+  Use as `write_xml(obj, filename, pretty=True)` and `obj.write(filename, pretty=True)`, respectively.
+- Removed argument `to_console` from methods `write_xml`, `TestSuite.write`, and `JUnitXml.write`.
+  Instead, use `write_xml(obj, sys.stdout)` and `obj.write(sys.stdout)`, respectively.
+- Renamed argument `filepath` of method `JUnitXml.fromfile` to `file`,
+  to reflect that this method supports file objects, file-like objects, and urls.
+
 ## [3.1.2] - 2024-08-31
 ### Fixed
 - the `TestCase.result` type annotation

--- a/junitparser/cli.py
+++ b/junitparser/cli.py
@@ -1,3 +1,4 @@
+import sys
 from argparse import ArgumentParser
 from glob import iglob
 from itertools import chain
@@ -14,7 +15,7 @@ def merge(paths, output, suite_name):
     result.update_statistics()
     if suite_name:
         result.name = suite_name
-    result.write(output, to_console=output == "-")
+    result.write(sys.stdout if output == "-" else output)
     return 0
 
 

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -26,14 +26,15 @@ def write_xml(obj, file_or_filename : Union[str, IO] = None, *, pretty: bool = F
         raise JUnitXmlError("Missing file argument.")
 
     if pretty:
-        xml_declaration = b'<?xml version="1.0" encoding="utf-8"?>\n'
-        content = etree.tounicode(obj._elem, pretty_print=True).encode("utf-8")
+        from xml.dom.minidom import parseString
+
+        text = etree.tostring(obj._elem)
+        xml = parseString(text)  # nosec
+        content = xml.toprettyxml(encoding="utf-8")
         if isinstance(file_or_filename, str):
             with open(file_or_filename, encoding="utf-8", mode="wb") as xmlfile:
-                xmlfile.write(xml_declaration)
                 xmlfile.write(content)
         else:
-            file_or_filename.write(xml_declaration)
             file_or_filename.write(content)
     else:
         tree.write(file_or_filename, encoding="utf-8", xml_declaration=True)
@@ -747,7 +748,7 @@ class JUnitXml(Element):
         - a file name/path
         - a file object
         - a file-like object
-        - a URL using the HTTP or FTP protocol
+        - a URL using the HTTP or FTP protocol (with lxml only)
         """
         if parse_func is not None:
             tree = parse_func(file)

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -26,10 +26,10 @@ def write_xml(obj, file_or_filename : Union[str, IO] = None, *, pretty: bool = F
         raise JUnitXmlError("Missing file argument.")
 
     if pretty:
-        xml_declaration = '<?xml version="1.0" encoding="utf-8"?>\n'
-        content = etree.tounicode(obj._elem, pretty_print=True)
+        xml_declaration = b'<?xml version="1.0" encoding="utf-8"?>\n'
+        content = etree.tounicode(obj._elem, pretty_print=True).encode("utf-8")
         if isinstance(file_or_filename, str):
-            with open(file_or_filename, encoding="utf-8", mode="wt") as xmlfile:
+            with open(file_or_filename, encoding="utf-8", mode="wb") as xmlfile:
                 xmlfile.write(xml_declaration)
                 xmlfile.write(content)
         else:

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -3,7 +3,6 @@
 import os
 import pytest
 from io import StringIO
-from tempfile import NamedTemporaryFile
 from junitparser import (
     TestCase,
     TestSuite,
@@ -148,22 +147,16 @@ def test_fromfile_with_testsuite_in_testsuite():
 
 
 def test_file_is_not_xml():
-    text = "Not really an xml file"
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="w", delete_on_close=False) as tmpfile:
-        tmpfile.write(text)
-        tmpfile.close()
-        with pytest.raises(Exception):
-            JUnitXml.fromfile(tmpfile.name)
-            # Raises lxml.etree.XMLSyntaxError
+    xmlfile = StringIO("Not really an xml file")
+    with pytest.raises(Exception):
+        JUnitXml.fromfile(xmlfile)
+        # Raises lxml.etree.XMLSyntaxError
 
 
 def test_illegal_xml_file():
-    text = "<some></some>"
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="w", delete_on_close=False) as tmpfile:
-        tmpfile.write(text)
-        tmpfile.close()
-        with pytest.raises(JUnitXmlError):
-            JUnitXml.fromfile(tmpfile.name)
+    xmlfile = StringIO("<some></some>")
+    with pytest.raises(JUnitXmlError):
+        JUnitXml.fromfile(xmlfile)
 
 
 def test_multi_results_in_case():

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+from tempfile import NamedTemporaryFile
 from junitparser import (
     TestCase,
     TestSuite,
@@ -23,17 +24,6 @@ try:
     has_lxml = True
 except ImportError:
     has_lxml = False
-
-
-@pytest.fixture(scope="module")
-def tmpfile():
-    import tempfile
-
-    fd, tmp = tempfile.mkstemp(suffix=".xml")
-    yield tmp
-    os.close(fd)
-    if os.path.exists(tmp):
-        os.remove(tmp)
 
 
 def test_fromfile():
@@ -104,91 +94,23 @@ def test_fromfile_with_testsuite_in_testsuite():
     assert len(all_cases[2].result) == 0
 
 
-def test_write_xml_without_testsuite_tag(tmpfile):
-    suite = TestSuite()
-    suite.name = "suite1"
-    case = TestCase()
-    case.name = "case1"
-    suite.add_testcase(case)
-    suite.write(tmpfile)
-    with open(tmpfile) as f:
-        text = f.read()
-    assert "suite1" in text
-    assert "case1" in text
-
-
-def test_file_is_not_xml(tmpfile):
+def test_file_is_not_xml():
     text = "Not really an xml file"
-    with open(tmpfile, "w") as f:
-        f.write(text)
-    with pytest.raises(Exception):
-        JUnitXml.fromfile(tmpfile)
-        # Raises lxml.etree.XMLSyntaxError
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="w", delete_on_close=False) as tmpfile:
+        tmpfile.write(text)
+        tmpfile.close()
+        with pytest.raises(Exception):
+            JUnitXml.fromfile(tmpfile.name)
+            # Raises lxml.etree.XMLSyntaxError
 
 
-def test_illegal_xml_file(tmpfile):
+def test_illegal_xml_file():
     text = "<some></some>"
-    with open(tmpfile, "w") as f:
-        f.write(text)
-    with pytest.raises(JUnitXmlError):
-        JUnitXml.fromfile(tmpfile)
-
-
-def test_write(tmpfile):
-    suite1 = TestSuite()
-    suite1.name = "suite1"
-    case1 = TestCase()
-    case1.name = "case1"
-    suite1.add_testcase(case1)
-    result = JUnitXml()
-    result.add_testsuite(suite1)
-    result.write(tmpfile)
-    with open(tmpfile) as f:
-        text = f.read()
-    assert "suite1" in text
-    assert "case1" in text
-
-
-def test_write_noarg():
-    suite1 = TestSuite()
-    suite1.name = "suite1"
-    case1 = TestCase()
-    case1.name = "case1"
-    suite1.add_testcase(case1)
-    result = JUnitXml()
-    result.add_testsuite(suite1)
-    with pytest.raises(JUnitXmlError):
-        result.write()
-
-
-def test_write_nonascii(tmpfile):
-    suite1 = TestSuite()
-    suite1.name = "suite1"
-    case1 = TestCase()
-    case1.name = "用例1"
-    suite1.add_testcase(case1)
-    result = JUnitXml()
-    result.add_testsuite(suite1)
-    result.write(tmpfile)
-    with open(tmpfile, encoding="utf-8") as f:
-        text = f.read()
-    assert "suite1" in text
-    assert "用例1" in text
-
-
-def test_read_written_xml(tmpfile):
-    suite1 = TestSuite()
-    suite1.name = "suite1"
-    case1 = TestCase()
-    case1.name = "用例1"
-    suite1.add_testcase(case1)
-    result = JUnitXml()
-    result.add_testsuite(suite1)
-    result.write(tmpfile)
-    xml = JUnitXml.fromfile(tmpfile)
-    suite = next(iter(xml))
-    case = next(iter(suite))
-    assert case.name == "用例1"
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="w", delete_on_close=False) as tmpfile:
+        tmpfile.write(text)
+        tmpfile.close()
+        with pytest.raises(JUnitXmlError):
+            JUnitXml.fromfile(tmpfile.name)
 
 
 def test_multi_results_in_case():
@@ -206,18 +128,3 @@ def test_multi_results_in_case():
     suite = next(iter(xml))
     case = next(iter(suite))
     assert len(case.result) == 2
-
-
-def test_write_pretty(tmpfile):
-    suite1 = TestSuite()
-    suite1.name = "suite1"
-    case1 = TestCase()
-    case1.name = "用例1"
-    suite1.add_testcase(case1)
-    result = JUnitXml()
-    result.add_testsuite(suite1)
-    result.write(tmpfile, pretty=True)
-    xml = JUnitXml.fromfile(tmpfile)
-    suite = next(iter(xml))
-    case = next(iter(suite))
-    assert case.name == "用例1"

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -2,7 +2,9 @@
 
 import os
 import pytest
+import sys
 from io import StringIO
+from unittest import skipIf
 from junitparser import (
     TestCase,
     TestSuite,
@@ -63,6 +65,7 @@ def test_fromfile_filelike_obj():
     do_test_fromfile(FileObject())
 
 
+@skipIf(sys.version.startswith("3.6.") or not has_lxml, "lxml not installed")
 def test_fromfile_url():
     from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
     import threading

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import os
 import pytest
+from tempfile import NamedTemporaryFile
 from junitparser import (
     TestCase,
     TestSuite,
@@ -25,31 +25,22 @@ except ImportError:
     has_lxml = False
 
 
-@pytest.fixture(scope="module")
-def tmpfile():
-    import tempfile
-
-    fd, tmp = tempfile.mkstemp(suffix=".xml")
-    yield tmp
-    os.close(fd)
-    if os.path.exists(tmp):
-        os.remove(tmp)
-
-
-def test_write_xml_without_testsuite_tag(tmpfile):
+def test_write_xml_without_testsuite_tag():
     suite = TestSuite()
     suite.name = "suite1"
     case = TestCase()
     case.name = "case1"
     suite.add_testcase(case)
-    suite.write(tmpfile)
-    with open(tmpfile) as f:
-        text = f.read()
+
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
+        suite.write(tmpfile.name)
+        text = tmpfile.read()
+
     assert "suite1" in text
     assert "case1" in text
 
 
-def test_write(tmpfile):
+def test_write():
     suite1 = TestSuite()
     suite1.name = "suite1"
     case1 = TestCase()
@@ -57,9 +48,11 @@ def test_write(tmpfile):
     suite1.add_testcase(case1)
     result = JUnitXml()
     result.add_testsuite(suite1)
-    result.write(tmpfile)
-    with open(tmpfile) as f:
-        text = f.read()
+
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
+        result.write(tmpfile.name)
+        text = tmpfile.read()
+
     assert "suite1" in text
     assert "case1" in text
 
@@ -76,7 +69,7 @@ def test_write_noarg():
         result.write()
 
 
-def test_write_nonascii(tmpfile):
+def test_write_nonascii():
     suite1 = TestSuite()
     suite1.name = "suite1"
     case1 = TestCase()
@@ -84,14 +77,16 @@ def test_write_nonascii(tmpfile):
     suite1.add_testcase(case1)
     result = JUnitXml()
     result.add_testsuite(suite1)
-    result.write(tmpfile)
-    with open(tmpfile, encoding="utf-8") as f:
-        text = f.read()
+
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
+        result.write(tmpfile.name)
+        text = tmpfile.read()
+
     assert "suite1" in text
     assert "用例1" in text
 
 
-def test_read_written_xml(tmpfile):
+def test_read_written_xml():
     suite1 = TestSuite()
     suite1.name = "suite1"
     case1 = TestCase()
@@ -99,14 +94,17 @@ def test_read_written_xml(tmpfile):
     suite1.add_testcase(case1)
     result = JUnitXml()
     result.add_testsuite(suite1)
-    result.write(tmpfile)
-    xml = JUnitXml.fromfile(tmpfile)
+
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
+        result.write(tmpfile.name)
+        xml = JUnitXml.fromfile(tmpfile.name)
+
     suite = next(iter(xml))
     case = next(iter(suite))
     assert case.name == "用例1"
 
 
-def test_write_pretty(tmpfile):
+def test_write_pretty():
     suite1 = TestSuite()
     suite1.name = "suite1"
     case1 = TestCase()
@@ -114,8 +112,11 @@ def test_write_pretty(tmpfile):
     suite1.add_testcase(case1)
     result = JUnitXml()
     result.add_testsuite(suite1)
-    result.write(tmpfile, pretty=True)
-    xml = JUnitXml.fromfile(tmpfile)
+
+    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
+        result.write(tmpfile.name, pretty=True)
+        xml = JUnitXml.fromfile(tmpfile.name)
+
     suite = next(iter(xml))
     case = next(iter(suite))
     assert case.name == "用例1"

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+import os
+import pytest
+from junitparser import (
+    TestCase,
+    TestSuite,
+    Skipped,
+    Failure,
+    Error,
+    Attr,
+    JUnitXmlError,
+    JUnitXml,
+    Property,
+    Properties,
+    IntAttr,
+    FloatAttr,
+)
+
+try:
+    from lxml.etree import XMLParser, parse
+
+    has_lxml = True
+except ImportError:
+    has_lxml = False
+
+
+@pytest.fixture(scope="module")
+def tmpfile():
+    import tempfile
+
+    fd, tmp = tempfile.mkstemp(suffix=".xml")
+    yield tmp
+    os.close(fd)
+    if os.path.exists(tmp):
+        os.remove(tmp)
+
+
+def test_write_xml_without_testsuite_tag(tmpfile):
+    suite = TestSuite()
+    suite.name = "suite1"
+    case = TestCase()
+    case.name = "case1"
+    suite.add_testcase(case)
+    suite.write(tmpfile)
+    with open(tmpfile) as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "case1" in text
+
+
+def test_write(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "case1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    with open(tmpfile) as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "case1" in text
+
+
+def test_write_noarg():
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "case1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    with pytest.raises(JUnitXmlError):
+        result.write()
+
+
+def test_write_nonascii(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    with open(tmpfile, encoding="utf-8") as f:
+        text = f.read()
+    assert "suite1" in text
+    assert "用例1" in text
+
+
+def test_read_written_xml(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile)
+    xml = JUnitXml.fromfile(tmpfile)
+    suite = next(iter(xml))
+    case = next(iter(suite))
+    assert case.name == "用例1"
+
+
+def test_write_pretty(tmpfile):
+    suite1 = TestSuite()
+    suite1.name = "suite1"
+    case1 = TestCase()
+    case1.name = "用例1"
+    suite1.add_testcase(case1)
+    result = JUnitXml()
+    result.add_testsuite(suite1)
+    result.write(tmpfile, pretty=True)
+    xml = JUnitXml.fromfile(tmpfile)
+    suite = next(iter(xml))
+    case = next(iter(suite))
+    assert case.name == "用例1"

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -36,8 +36,11 @@ def test_write_xml_without_testsuite_tag():
         suite.write(tmpfile.name)
         text = tmpfile.read()
 
-    assert "suite1" in text
-    assert "case1" in text
+    assert text == (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        '<testsuite name="suite1" tests="1" errors="0" failures="0" skipped="0" '
+        'time="0"><testcase name="case1"/></testsuite>'
+    )
 
 
 def test_write():
@@ -53,9 +56,11 @@ def test_write():
         result.write(tmpfile.name)
         text = tmpfile.read()
 
-    assert "suite1" in text
-    assert "case1" in text
-
+    assert text == (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        '<testsuites><testsuite name="suite1" tests="1" errors="0" failures="0" '
+        'skipped="0" time="0"><testcase name="case1"/></testsuite></testsuites>'
+    )
 
 def test_write_noarg():
     suite1 = TestSuite()
@@ -82,8 +87,11 @@ def test_write_nonascii():
         result.write(tmpfile.name)
         text = tmpfile.read()
 
-    assert "suite1" in text
-    assert "用例1" in text
+    assert text == (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        '<testsuites><testsuite name="suite1" tests="1" errors="0" failures="0" '
+        'skipped="0" time="0"><testcase name="用例1"/></testsuite></testsuites>'
+    )
 
 
 def test_read_written_xml():
@@ -97,7 +105,14 @@ def test_read_written_xml():
 
     with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
         result.write(tmpfile.name)
+        text = tmpfile.read()
         xml = JUnitXml.fromfile(tmpfile.name)
+
+    assert text == (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        '<testsuites><testsuite name="suite1" tests="1" errors="0" failures="0" '
+        'skipped="0" time="0"><testcase name="用例1"/></testsuite></testsuites>'
+    )
 
     suite = next(iter(xml))
     case = next(iter(suite))
@@ -115,7 +130,17 @@ def test_write_pretty():
 
     with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
         result.write(tmpfile.name, pretty=True)
+        text = tmpfile.read()
         xml = JUnitXml.fromfile(tmpfile.name)
+
+    assert text == (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<testsuites>\n'
+        '\t<testsuite name="suite1" tests="1" errors="0" failures="0" skipped="0" time="0">\n'
+        '\t\t<testcase name="用例1"/>\n'
+        '\t</testsuite>\n'
+        '</testsuites>\n'
+    )
 
     suite = next(iter(xml))
     case = next(iter(suite))

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 import sys
 from io import BytesIO

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -33,11 +33,10 @@ def test_write_xml_without_testsuite_tag():
     case.name = "case1"
     suite.add_testcase(case)
 
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
-        suite.write(tmpfile.name)
-        text = tmpfile.read()
+    xmlfile = BytesIO()
+    suite.write(xmlfile)
 
-    assert text == (
+    assert xmlfile.getvalue().decode("utf-8") == (
         "<?xml version='1.0' encoding='UTF-8'?>\n"
         '<testsuite name="suite1" tests="1" errors="0" failures="0" skipped="0" '
         'time="0"><testcase name="case1"/></testsuite>'
@@ -111,11 +110,10 @@ def test_write_nonascii():
     result = JUnitXml()
     result.add_testsuite(suite1)
 
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
-        result.write(tmpfile.name)
-        text = tmpfile.read()
+    xmlfile = BytesIO()
+    result.write(xmlfile)
 
-    assert text == (
+    assert xmlfile.getvalue().decode("utf-8") == (
         "<?xml version='1.0' encoding='UTF-8'?>\n"
         '<testsuites><testsuite name="suite1" tests="1" errors="0" failures="0" '
         'skipped="0" time="0"><testcase name="用例1"/></testsuite></testsuites>'
@@ -131,17 +129,17 @@ def test_read_written_xml():
     result = JUnitXml()
     result.add_testsuite(suite1)
 
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
-        result.write(tmpfile.name)
-        text = tmpfile.read()
-        xml = JUnitXml.fromfile(tmpfile.name)
+    xmlfile = BytesIO()
+    result.write(xmlfile)
 
-    assert text == (
+    assert xmlfile.getvalue().decode("utf-8") == (
         "<?xml version='1.0' encoding='UTF-8'?>\n"
         '<testsuites><testsuite name="suite1" tests="1" errors="0" failures="0" '
         'skipped="0" time="0"><testcase name="用例1"/></testsuite></testsuites>'
     )
 
+    xmlfile.seek(0)
+    xml = JUnitXml.fromfile(xmlfile)
     suite = next(iter(xml))
     case = next(iter(suite))
     assert case.name == "用例1"
@@ -156,12 +154,10 @@ def test_write_pretty():
     result = JUnitXml()
     result.add_testsuite(suite1)
 
-    with NamedTemporaryFile(suffix=".xml", encoding="utf-8", mode="rt") as tmpfile:
-        result.write(tmpfile.name, pretty=True)
-        text = tmpfile.read()
-        xml = JUnitXml.fromfile(tmpfile.name)
+    xmlfile = BytesIO()
+    result.write(xmlfile, pretty=True)
 
-    assert text == (
+    assert xmlfile.getvalue().decode("utf-8") == (
         '<?xml version="1.0" encoding="utf-8"?>\n'
         '<testsuites>\n'
         '  <testsuite name="suite1" tests="1" errors="0" failures="0" skipped="0" time="0">\n'
@@ -170,6 +166,8 @@ def test_write_pretty():
         '</testsuites>\n'
     )
 
+    xmlfile.seek(0)
+    xml = JUnitXml.fromfile(xmlfile)
     suite = next(iter(xml))
     case = next(iter(suite))
     assert case.name == "用例1"


### PR DESCRIPTION
Method `fromfile` already supports reading file objects, file-like objects and urls. This is now tested and documented.

Similarly, methods `write_xml` and `write` now support writing to file objects and file-like objects. This makes `to_console` argument redundant.

Asserts the actual written XML content.