### PR TITLE
Remove Ubuntu 20.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
       # EOL Python versions
       include: >
         [
-          {"os": "ubuntu-20.04", "python-version": "3.6"},
-          {"os": "ubuntu-20.04", "python-version": "3.7"},
           {"os": "ubuntu-22.04", "python-version": "3.8"},
         ]
 
@@ -132,7 +130,5 @@ jobs:
       # EOL Python versions
       include: >
         [
-          {"os": "ubuntu-20.04", "python-version": "3.6"},
-          {"os": "ubuntu-20.04", "python-version": "3.7"},
           {"os": "ubuntu-22.04", "python-version": "3.8"},
         ]


### PR DESCRIPTION
Ubuntu 20.04 will be sunset by <strike>2024-04-01</strike> 2024-04-15.

With this, we lose test coverage for Python 3.6 an 3.7.

https://github.com/actions/runner-images/issues/11101