### PR TITLE
Enable inheritance

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -653,8 +653,7 @@ class TestSuite(Element):
 
     def testsuites(self):
         """Iterate through all testsuites."""
-        for suite in self.iterchildren(TestSuite):
-            yield suite
+        yield from self.iterchildren(type(self))
 
     def write(self, file_or_filename: Optional[Union[str, IO]] = None, *, pretty: bool = False):
         write_xml(self, file_or_filename=file_or_filename, pretty=pretty)
@@ -696,7 +695,7 @@ class JUnitXml(Element):
         return len(list(self.__iter__()))
 
     def __add__(self, other):
-        result = JUnitXml()
+        result = type(self)()
         for suite in self:
             result.add_testsuite(suite)
         for suite in other:
@@ -708,7 +707,7 @@ class JUnitXml(Element):
             for suite in other:
                 self.add_testsuite(suite)
         elif other._elem.tag == "testsuite":
-            suite = TestSuite(name=other.name)
+            suite = self.testsuite(name=other.name)
             for case in other:
                 suite._add_testcase_no_update_stats(case)
             self.add_testsuite(suite)

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -514,6 +514,7 @@ class TestSuite(Element):
         super().__init__(self._tag)
         self.name = name
         self.filepath = None
+        self.root = JUnitXml
 
     def __iter__(self) -> Iterator[TestCase]:
         return itertools.chain(
@@ -552,7 +553,7 @@ class TestSuite(Element):
             result.update_statistics()
         else:
             # Create a new test result containing two testsuites
-            result = JUnitXml()
+            result = self.root()
             result.add_testsuite(self)
             result.add_testsuite(other)
         return result
@@ -566,7 +567,7 @@ class TestSuite(Element):
             self.update_statistics()
             return self
 
-        result = JUnitXml()
+        result = self.root()
         result.filepath = self.filepath
         result.add_testsuite(self)
         result.add_testsuite(other)

--- a/junitparser/xunit2.py
+++ b/junitparser/xunit2.py
@@ -168,6 +168,10 @@ class TestSuite(junitparser.TestSuite):
 
     testcase = TestCase
 
+    def __init__(self, name=None):
+        super().__init__(name)
+        self.root = JUnitXml
+
     @property
     def system_out(self):
         """<system-out>"""

--- a/tests/test_xunit2.py
+++ b/tests/test_xunit2.py
@@ -162,6 +162,7 @@ class Test_TestSuite:
         suite = TestSuite("mySuite")
         suite.add_testsuite(TestSuite("suite1"))
         suite = next(suite.testsuites())
+        assert isinstance(suite, TestSuite)
         assert suite.name == "suite1"
 
     def test_remove_case(self):
@@ -170,6 +171,20 @@ class Test_TestSuite:
         suite.add_testcase(test)
         suite.remove_testcase(test)
         assert len(suite) == 0
+
+    def test_add_testsuites(self):
+        suite1 = TestSuite("suite1")
+        suite2 = TestSuite("suite2")
+        suites = suite1 + suite2
+        assert isinstance(suites, JUnitXml)
+        assert len(list(iter(suites))) == 2
+
+    def test_iadd_testsuites(self):
+        suite1 = TestSuite("suite1")
+        suite2 = TestSuite("suite2")
+        suite1 += suite2
+        assert isinstance(suite1, JUnitXml)
+        assert len(list(iter(suite1))) == 2
 
 
 class Test_JUnitXml:


### PR DESCRIPTION
Follow up on #143, now it should be possible to properly derive all 3 classes (JUnitXml, TestSuite, TestCase) without loosing information while e.g. adding 2 testsuites to each other.