### PR TITLE
Fix __add__: mutated arguments after operation

### DIFF
--- a/src/junitparser/junitparser.py
+++ b/src/junitparser/junitparser.py
@@ -728,9 +728,9 @@ class JUnitXml(Element):
     def __add__(self, other):
         result = type(self)()
         for suite in self:
-            result.add_testsuite(suite)
+            result.add_testsuite(deepcopy(suite))
         for suite in other:
-            result.add_testsuite(suite)
+            result.add_testsuite(deepcopy(suite))
         return result
 
     def __iadd__(self, other):

--- a/src/junitparser/junitparser.py
+++ b/src/junitparser/junitparser.py
@@ -728,9 +728,9 @@ class JUnitXml(Element):
     def __add__(self, other):
         result = type(self)()
         for suite in self:
-            result.add_testsuite(deepcopy(suite))
+            result.add_testsuite(suite)
         for suite in other:
-            result.add_testsuite(deepcopy(suite))
+            result.add_testsuite(suite)
         return result
 
     def __iadd__(self, other):
@@ -747,6 +747,7 @@ class JUnitXml(Element):
         return self
 
     def add_testsuite(self, suite: TestSuite):
+        suite = deepcopy(suite)
         """Add a testsuite."""
         for existing_suite in self:
             if existing_suite == suite:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -249,6 +249,31 @@ class Test_JunitXml:
         assert len(case) == 1
         assert case[0].attrib["name"] == "case1"
 
+    def test_add_does_not_mutate_operands(self):
+        text = """<testsuites>
+        <testsuite errors="1" failures="0" hostname="hooch" name="pytest" skipped="1" tests="3" time="0.025"
+        timestamp="2020-02-05T10:52:33.843536">
+        <testcase classname="test_x" file="test_x.py" line="7" name="test_comp_1" time="0.000"/>
+        <testcase classname="test_x" file="test_x.py" line="10" name="test_comp_2" time="0.000">
+        <skipped message="unconditional skip" type="pytest.skip">test_x.py:11: unconditional skip</skipped>
+        <error message="test teardown failure">
+        @pytest.fixture(scope="module") def compb(): yield > raise PermissionError E
+        PermissionError test_x.py:6: PermissionError
+        </error>
+        </testcase>
+        </testsuite>
+        </testsuites>"""
+        a = JUnitXml.fromstring(text)
+        b = JUnitXml.fromstring(text)
+
+        result = a + b
+        assert a.tests == 2, f"Operand 'a' was mutated! tests={a.tests}"
+        assert b.tests == 2, f"Operand 'b' was mutated! tests={b.tests}"
+        assert result.tests == 4, f"Result wrong: tests={result.tests}"
+        _ = a + b
+        assert a.tests == 2, "Operand 'a' emptied after uncaptured +"
+        assert b.tests == 2, "Operand 'b' emptied after uncaptured +"
+
     def test_add(self):
         result1 = JUnitXml()
         suite1 = TestSuite("suite1")


### PR DESCRIPTION
This started with a issue #177 that I posted.
So I recommend reading it to understand the description of this PR.

## Description
I found that after making the __add__ on the Object `JUnitXml` the arguments would mutate, making the second __add__ with the same arguments different. Which I believe is not desirable.

## Problem 1
The behavior described in the issue happens because of the function `.append(child)` of `etree`.
The `etree` can come from two libraries as you can see form the snippet taken from the source code:
```python
try:
    from lxml import etree
except ImportError:
    from xml.etree import ElementTree as etree
```

When a the function `.append(child)` is called and the child already as a parent, both libraries operate in different ways.

### lxml
With this library when the .append(child) is trigger it moves each child from the original tree to the new tree.
That explains why in the code I shared in the PR, after the first `+` in the logger all the testsuites where moved to a new object and latter garage collected. When the `+`is called again both vars don't have any tests.

### xml.etree
This is trickier.
the behavior is actually simpler just gives the child to the new parent, but the child will have two parents at the same time. Although I could not find any error I believe that this can be prone to error. 

## Problem 2
This problem arises when the arguments of the `__add__` where considered under the function ` __eq__`  that they had equal suites. 
Because of the call `_add_testcase_no_update_stats(case)`, it changes the suites making it with duplicate cases. 
This error only happens when using `xml.etree`, and that's because the values where not move at first.

```python
def add_testsuite(self, suite):                                   
    for existing_suite in self: 
        if existing_suite == suite: # Considered equal
            for case in suite:
                existing_suite._add_testcase_no_update_stats(case) # Adds to the suite permanently
            return
```
## Test
The test made covers both problems at the same time (:

## Fix
The fix is actually pretty simple, I just called `deepcopy(suite)` in  the beginning of the function `add_testsuite(self, suite)`. 

## Additional Notes
In the end a lot of yapping for a simple solution. If you have any questions feel free to ask.