### PR TITLE
ci: add PyPI publish attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v6
-    - name: Install uv
-      uses: astral-sh/setup-uv@v8.1.0
     - name: Download Binaries
       uses: actions/download-artifact@v8.0.1
       with:
@@ -117,4 +115,4 @@ jobs:
         version=$(python -c "from pathlib import Path; import tomllib; data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8')); print(data['project']['version'])")
         test "$tag" = "$version"
     - name: Publish to PyPI
-      run: uv publish --trusted-publishing always
+      uses: pypa/gh-action-pypi-publish@v1.14.0


### PR DESCRIPTION
### Summary

Hi! This switches the tag-only PyPI upload step from `uv publish` to `pypa/gh-action-pypi-publish@v1.14.0`.

`junitparser` already publishes from GitHub Actions using PyPI Trusted Publishing/OIDC. Using the official PyPA publish action keeps that flow, but also generates and uploads PyPI publish attestations by default, so this should not require any new PyPI-side configuration or secrets.

Those attestations bind each uploaded distribution to the trusted GitHub Actions publisher that uploaded it, making that provenance available through PyPI for downstream users and tooling.

This also removes the `uv` setup step from the publish job, since the upload step no longer uses `uv`.

### Possible follow-ups

I kept this PR intentionally small for reviewability, but noticed a few related release-hardening opportunities while looking at the workflow:

- Pin GitHub Actions to full commit SHAs.
- Avoid cache use in release artifact builds.
- Split build and publish into separate jobs, so `id-token: write` is only available in the final upload job.

### Testing

Not run; workflow-only change.